### PR TITLE
Implementing CYK Algorithm

### DIFF
--- a/aima-core/src/main/java/aima/core/nlp/data/grammars/ProbCNFGrammarExamples.java
+++ b/aima-core/src/main/java/aima/core/nlp/data/grammars/ProbCNFGrammarExamples.java
@@ -1,0 +1,83 @@
+package aima.core.nlp.data.grammars;
+
+import java.util.ArrayList;
+
+import aima.core.nlp.data.lexicons.LexiconExamples;
+import aima.core.nlp.parsing.Lexicon;
+import aima.core.nlp.parsing.grammars.ProbCNFGrammar;
+import aima.core.nlp.parsing.grammars.Rule;
+
+/**
+ * A store of example Probabilistic Chomsky-Normal-Form grammars for testing and 
+ * demonstrating CYK.
+ * @author Jonathon
+ *
+ */
+public class ProbCNFGrammarExamples {
+	
+	/** 
+	 * An elementary Chomsky-Normal-Form grammar for simple testing and 
+	 * demonstrating. This type of grammar is seen more in Computing Theory classes,
+	 * and does not mock a subset of English phrase-structure.
+	 * @return
+	 */
+	public static ProbCNFGrammar buildExampleGrammarOne() {
+		ProbCNFGrammar g = new ProbCNFGrammar();
+		ArrayList<Rule> rules = new ArrayList<Rule>();
+		// Start Rules
+		rules.add( new Rule( "S", "Y,Z", (float)0.10));
+		rules.add( new Rule( "B", "B,D", (float)0.10));
+		rules.add( new Rule( "B", "G,D", (float)0.10));
+		rules.add( new Rule( "C", "E,C", (float)0.10));
+		rules.add( new Rule( "C", "E,H", (float)0.10));
+		rules.add( new Rule( "E", "M,N", (float)0.10));
+		rules.add( new Rule( "D", "M,N", (float)0.10));
+		rules.add( new Rule( "Y", "E,C", (float)0.10));
+		rules.add( new Rule( "Z", "E,C", (float)0.10));
+		
+		// Terminal Rules
+		rules.add( new Rule( "M", "m", (float)1.0));
+		rules.add( new Rule( "N", "n", (float)1.0));
+		rules.add( new Rule( "B", "a", (float)0.25));
+		rules.add( new Rule( "B", "b", (float)0.25));
+		rules.add( new Rule( "B", "c", (float)0.25));
+		rules.add( new Rule( "B", "d", (float)0.25));
+		rules.add( new Rule( "G", "a", (float)0.50));
+		rules.add( new Rule( "G", "d", (float)0.50));
+		rules.add( new Rule( "C", "x", (float)0.20));
+		rules.add( new Rule( "C", "y", (float)0.20));
+		rules.add( new Rule( "C", "z", (float)0.60));
+		rules.add( new Rule( "H", "u", (float)0.50));
+		rules.add( new Rule( "H", "z", (float)0.50));
+		
+		// Add all these rules into the grammar
+		if(!g.addRules(rules)) {
+			return null;
+		}
+		return g; 
+	}
+	
+	/**
+	 * A more restrictive phrase-structure grammar, used in testing and demonstrating 
+	 * the CYK Algorithm. 
+	 * Note: It is complemented by the "trivial lexicon" in LexiconExamples.java
+	 * @return
+	 */
+	public static ProbCNFGrammar buildTrivialGrammar() {
+		ProbCNFGrammar g = new ProbCNFGrammar();
+		ArrayList<Rule> rules = new ArrayList<Rule>();
+		rules.add( new Rule( "S", "NP,VP", (float)1.0));
+		rules.add( new Rule( "NP", "ARTICLE,NOUN", (float)0.50));
+		rules.add( new Rule( "NP", "PRONOUN,ADVERB", (float)0.5));
+		rules.add( new Rule( "VP", "VERB,NP", (float)1.0));
+		// add terminal rules
+		Lexicon trivLex = LexiconExamples.buildTrivialLexicon();
+		ArrayList<Rule> terminalRules = new ArrayList<Rule>(trivLex.getAllTerminalRules());
+		rules.addAll(terminalRules);
+		// Add all these rules into the grammar
+		if(!g.addRules(rules)) {
+			return null;
+		}
+		return g;
+	}
+}

--- a/aima-core/src/main/java/aima/core/nlp/data/grammars/ProbContextFreeExamples.java
+++ b/aima-core/src/main/java/aima/core/nlp/data/grammars/ProbContextFreeExamples.java
@@ -1,0 +1,58 @@
+package aima.core.nlp.data.grammars;
+
+import java.util.ArrayList;
+
+import aima.core.nlp.data.lexicons.LexiconExamples;
+import aima.core.nlp.parsing.Lexicon;
+import aima.core.nlp.parsing.grammars.ProbContextFreeGrammar;
+import aima.core.nlp.parsing.grammars.Rule;
+
+public class ProbContextFreeExamples {
+
+	public static ProbContextFreeGrammar buildWumpusGrammar() {
+		ProbContextFreeGrammar g = new ProbContextFreeGrammar();
+		ArrayList<Rule> rules = new ArrayList<Rule>();
+		// Start Rules
+		rules.add( new Rule( "S", "NP,VP", (float)0.90));
+		rules.add( new Rule( "S", "CONJ,S", (float)0.10));
+		// Noun Phrase Rules
+		rules.add( new Rule( "NP", "PRONOUN", (float)0.30));
+		rules.add( new Rule( "NP", "NAME" , (float)0.10));
+		rules.add( new Rule( "NP", "NOUN" , (float)0.10));
+		rules.add( new Rule( "NP", "ARTICLE,NOUN", (float)0.25));
+		rules.add( new Rule( "NP", "AP,NOUN", (float)0.05));
+		rules.add( new Rule( "NP", "DIGIT,DIGIT", (float)0.05));
+		rules.add( new Rule( "NP", "NP,PP", (float)0.10));
+		rules.add( new Rule( "NP", "NP,RELCLAUSE", (float)0.05));
+		// add verb phrase rules
+		rules.add( new Rule( "VP", "VERB", (float)0.40));
+		rules.add( new Rule( "VP", "VP,NP", (float)0.35));
+		rules.add( new Rule( "VP", "VP,ADJS", (float)0.05));
+		rules.add( new Rule( "VP", "VP,PP", (float)0.10));
+		rules.add( new Rule( "VP", "VP,ADVERB", (float)0.10));
+		// add adjective rules
+		rules.add( new Rule( "AJD", "AJDS", (float)0.80));
+		rules.add( new Rule( "AJD", "AJD,AJDS", (float)0.20));
+		// add Article Phrase
+		// This deviates from the text because the text provides the rule:
+		// NP -> Article Adjs Noun, which is NOT in Chomsky Normal Form
+		//
+		// We instead define AP (Article Phrase) AP -> Article Adjs, to get around this
+		rules.add( new Rule( "AP", "ARTICLE,ADJS", (float)1.0));
+		// add preposition phrase
+		rules.add( new Rule( "PP", "PREP,NP", (float)1.00));
+		// add relative clause
+		rules.add( new Rule( "RELCLAUSE", "RELPRO,VP", (float)1.00));
+		
+		// Now we can add all rules that derive terminal symbols, which are in 
+		// this case words.
+		Lexicon wumpusLex = LexiconExamples.buildWumpusLex();
+		ArrayList<Rule> terminalRules = new ArrayList<Rule>(wumpusLex.getAllTerminalRules());
+		rules.addAll( terminalRules );
+		// Add all these rules into the grammar
+		if(!g.addRules(rules)) {
+			return null;
+		}
+		return g; 
+	}
+}

--- a/aima-core/src/main/java/aima/core/nlp/data/lexicons/LexiconExamples.java
+++ b/aima-core/src/main/java/aima/core/nlp/data/lexicons/LexiconExamples.java
@@ -1,0 +1,129 @@
+package aima.core.nlp.data.lexicons;
+
+import java.util.ArrayList;
+
+import aima.core.nlp.parsing.LexWord;
+import aima.core.nlp.parsing.Lexicon;
+
+/**
+ * A store of simple lexicon's for the purpose of testing and demonstrating the CYK Algorithm.
+ * @author Jonathon
+ *
+ */
+public class LexiconExamples {
+	
+	
+	/**
+	 * Builds an expanded version of the 'wumpus lexicon' found on page 891 of AIMA V3
+	 * @return
+	 */
+	public static Lexicon buildWumpusLex() {
+		Lexicon l = new Lexicon();
+		ArrayList<LexWord> list = new ArrayList<LexWord>();
+		// noun list
+		list.add( new LexWord("stench", (float)0.05)); 
+		list.add( new LexWord("breeze", (float)0.10));
+		list.add( new LexWord("wumpus", (float)0.15));
+		list.add( new LexWord("pits", (float)0.05));
+		list.add( new LexWord("friend", (float)0.10)); // not in textbook
+		list.add( new LexWord("enemy", (float)0.10)); // not in textbook
+		list.add( new LexWord("dog", (float)0.10)); // not in textbook
+		list.add( new LexWord("superhero", (float)0.20)); // not in textbook
+		list.add( new LexWord("virus", (float)0.15)); // not in textbook
+		l.put("NOUN", list );
+		// verb list
+		ArrayList<LexWord> verbList = new ArrayList<LexWord>();
+		verbList.add( new LexWord( "is", (float)0.10));
+		verbList.add( new LexWord( "feel", (float)0.10));
+		verbList.add( new LexWord( "smells", (float)0.10));
+		verbList.add( new LexWord( "stinks", (float)0.05));
+		verbList.add( new LexWord( "wants", (float)0.20)); // not in textbook
+		verbList.add( new LexWord( "flies", (float)0.10)); // not in textbook
+		verbList.add( new LexWord( "keeps", (float)0.05)); // not in textbook
+		verbList.add( new LexWord( "leaves", (float)0.10)); // not in textbook
+		verbList.add( new LexWord( "throws", (float)0.20)); // not in textbook
+		l.put("VERB", verbList);
+		// adjective list
+		ArrayList<LexWord> adjList = new ArrayList<LexWord>();
+		adjList.add( new LexWord( "right", (float)0.10));
+		adjList.add( new LexWord( "dead", (float)0.05));
+		adjList.add( new LexWord( "smelly", (float)0.02));
+		adjList.add( new LexWord( "breezy", (float)0.02));
+		adjList.add( new LexWord( "foul", (float)0.10));
+		adjList.add( new LexWord( "black", (float)0.05));
+		adjList.add( new LexWord( "white", (float)0.05));
+		adjList.add( new LexWord( "callous", (float)0.10));
+		adjList.add( new LexWord( "proud", (float)0.10));
+		adjList.add( new LexWord( "right", (float)0.10));
+		adjList.add( new LexWord( "gold", (float)0.06));
+		adjList.add( new LexWord( "normal", (float)0.25));
+		l.put("ADJS", adjList);
+		// Adverb list
+		l.addLexWords("ADVERB","here","0.05","ahead","0.05","nearby","0.02",
+					  "quickly","0.05", "badly", "0.05", "slowly", "0.08",
+					  "sadly","0.10", "silently","0.10","easily","0.10",
+					  "seldom","0.10","sometimes","0.10","loudly","0.10",
+					  "cordially","0.05", "frequently","0.05");
+		// Pronoun list
+		l.addLexWords("PRONOUN","me","0.10","you","0.03","i","0.10","it","0.10", // remember "I" has to be lowercase "i"
+					 		    "us","0.07","they","0.20","he","0.20","she","0.20");
+		// RelPro
+		l.addLexWords("RELPRO", "that","0.40","which","0.15","who","0.20","whom","0.02",
+								"whose","0.08","whabt","0.15");
+		// Name list
+		l.addLexWords( buildNameLexicon() );
+		
+		// Article list
+		l.addLexWords("ARTICLE", "the","0.40","a","0.30","an","0.10","every","0.05","some","0.15");
+		
+		// Prepositions list
+		l.addLexWords("PREP", "to","0.20","in","0.10","on","0.05","near","0.10","after","0.10",
+							  "among","0.05","around","0.20","against","0.10","across","0.10");
+		
+		// Conjugations list
+		l.addLexWords("CONJ", "and","0.50","or","0.10","but","0.20","yet","0.02","since","0.08",
+						      "unless","0.10");
+		
+		// Digits list
+		l.addLexWords("DIGIT", "0","0.20","1","0.20","2","0.20","3","0.20","4","0.20");
+		
+		return l;
+	}
+	
+	/**
+	 * A lexicon of names that complements the 'wumpus lexicon' above. There are 50 names 
+	 * of equal derivation likelihood (%2)
+	 * @return
+	 */
+	public static Lexicon buildNameLexicon() {
+		Lexicon l = new Lexicon();
+		String[] names = {"John","Mary","Boston","Xiao","Hollie","Kendrick","Beverly"
+		                  ,"Garnet","Zora","Shavonda","Peg","Katherin","Beatriz","Deirdre","Gaylord"
+		                  ,"Desirae","Tresa","Gwyneth","Rashida","Garfield","Pinkie","Claretta","Teressa"
+		                  ,"Andy","Eugena","Carie","Dinorah","Tess","Johnie","Keely","Antonetta","Darcey"
+		                  ,"Bud","Veta","Janey","Rosalina","Frederica","Lou","Essie","Marinda","Elene"
+		                  ,"Juliana","Marilyn","Maxima","Branden","Ethan","Donovan","Erinn","Ramon","Jacquiline"};
+		
+		for(int i=0; i < names.length; i++ ) {
+			l.addLexWords("NAME", names[i], "0.02");
+		}
+		
+		return l;
+		
+	}
+	
+	/**
+	 * A more restraining lexicon for simple testing and demonstration.
+	 * @return
+	 */
+	public static Lexicon buildTrivialLexicon() {
+		Lexicon l = new Lexicon();
+		l.addLexWords("ARTICLE", "the", "0.50","a","0.50");
+		l.addLexWords("NOUN", "man","0.20","woman","0.20","table","0.20","shoelace","0.20","saw","0.20");
+		l.addLexWords("PRONOUN","i","0.40","you","0.40","it","0.20"); // remember "I" has to be lowercase "i"
+		l.addLexWords("VERB","saw","0.30","liked","0.30","feel","0.40");
+		l.addLexWords("ADVERB", "happily","0.30","sadly","0.20","morosely","0.50");
+		return l;
+	}
+
+}

--- a/aima-core/src/main/java/aima/core/nlp/parsing/CYK.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/CYK.java
@@ -1,0 +1,130 @@
+package aima.core.nlp.parsing;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import aima.core.nlp.parsing.grammars.ProbCNFGrammar;
+import aima.core.nlp.parsing.grammars.ProbUnrestrictedGrammar;
+import aima.core.nlp.parsing.grammars.Rule;
+
+/**
+ * Artificial Intelligence A Modern Approach (3rd Edition): page 894.<br>
+ * <br>
+ * 
+ * <pre>
+ * function CYK-PARSE(words, grammar) returns P, a table of probabilities
+ *   N <- LENGTH(words)
+ *   M <- the number of nonterminal symbols in grammar
+ *   P <- an array of size[M,N,N], initially all 0
+ *   /* Insert Lexical rules for each word *\
+ *   for i = 1 to N do
+ *   	for each rule of form( X -> words<sub>i</sub>[p]) do
+ *   		P[X,i,1] <- p
+ *   /* Combine first and second parts of right-hand sides of rules, from short to long *\
+ *   for length = 2 to N do
+ *   	for start = 1 to N - length + 1 do
+ *   		for len1 = 1 to N -1 do 
+ *   			len2 <- length - len1
+ *   		for each rule of the form( X -> Y Z [p] ) do
+ *   			p[X, start, length] <- MAX(P[X, start, length],
+ *   						P[Y, start, len1] * P[Z, start + len1, len2] * p)
+ *   return P
+ * </pre>
+ * 
+ * Figure 23.5 The CYK algorithm for parsing. Given a sequence of words,
+ * it finds the most probable derivation for the whole sequence and for
+ * each subsequence. It returns the whole table, P, in which an entry 
+ * P[X, start, len] is the probability of the most probable X of length
+ * len starting at position start. If there is no X of that size at that
+ * location, the probability is 0.<br>
+ * <br>
+ * 
+ * @author Jonathon Belotti (thundergolfer)
+ *
+ */
+public class CYK {
+	
+	public float[][][] parse( List<String> words, ProbCNFGrammar grammar ) {
+		final int N = length(words);
+		final int M = grammar.vars.size(); 
+		float[][][] P = new float[M][N][N]; // initialised to 0.0
+		for( int i=0; i < N; i++ ) {
+		   //for each rule of form( X -> words<sub>i</sub>[p]) do
+			//   P[X,i,1] <- p
+			for( int j=0; j < grammar.rules.size(); j++ ) {
+				Rule r = (Rule) grammar.rules.get(j);
+				if( r.derives(words.get(i))) { 				 	// rule is of form X -> w, where w = words[i]
+					int x = grammar.vars.indexOf(r.lhs.get(0)); // get the index of rule's LHS variable
+					P[x][i][0] = r.PROB; 						// not P[X][i][1] because we use 0-based indexing
+				}
+			}
+		}
+		for( int length=2; length <= N; length++ ) {
+			for( int start=1; start <= N - length + 1; start++ ) {
+				for( int len1=1; len1 <= length -1; len1++ ) { // N.B. the book incorrectly has N-1 instead of length-1
+					int len2 = length - len1;
+					// for each rule of the form X -> Y Z, where Y,Z are variables of the grammar
+					for( int j=0; j < grammar.rules.size(); j++ ) {
+						Rule r = grammar.rules.get(j);
+						if( r.rhs.size() == 2 ) {
+							// get index of rule's variables X, Y, and Z
+							int x = grammar.vars.indexOf(r.lhs.get(0));
+							int y = grammar.vars.indexOf(r.rhs.get(0));
+							int z = grammar.vars.indexOf(r.rhs.get(1));
+							P[x][start-1][length-1] = Math.max( P[x][start-1][length-1],
+												  			P[y][start-1][len1-1] * 
+												  			P[z][start+len1-1][len2-1] * r.PROB);
+						}
+					}
+				}
+			}
+		}
+		return P;
+	}
+	
+	/**
+	 * Simple function to make algorithm more closely resemble pseudocode
+	 * @param ls
+	 * @return the length of the list
+	 */
+	public int length( List<String> ls ) {
+		return ls.size();
+	}
+	
+	/**
+	 * Print out the probability table produced by the CYK Algorithm
+	 * @param probTable
+	 * @param words
+	 * @param g
+	 */
+	public void printProbTable( float[][][] probTable, List<String> words, ProbUnrestrictedGrammar g ) {
+		final int N = words.size();
+		final int M = g.vars.size(); // num non-terminals in grammar
+		
+		for( int i=0; i < M; i++ ) {
+			System.out.println("Table For : " + g.vars.get(i) + "(" + i + ")");
+			for( int j=0; j < N; j++ ) {
+				System.out.print(j + "| ");
+				for( int k=0; k < N; k++ ) {
+					System.out.print(probTable[i][j][k] + " | ");
+				}
+				System.out.println();
+			}
+			System.out.println();
+		}
+	}
+	
+	/**
+	 * The probability table get's us halfway there, but this method can provide the 
+	 * derivation chain that most probably derives the words provided to the parser.
+	 * @param probTable
+	 * @param g
+	 * @return
+	 */
+	public ArrayList<String> getMostProbableDerivation( float[][][] probTable, ProbUnrestrictedGrammar g ) {
+		// TODO
+		return null;
+	}
+
+} // end of CYKParse() 
+

--- a/aima-core/src/main/java/aima/core/nlp/parsing/LexWord.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/LexWord.java
@@ -1,0 +1,14 @@
+package aima.core.nlp.parsing;
+
+public class LexWord {
+	String word;
+	Float  prob;
+	
+	public LexWord( String word, Float prob ) {
+		this.word = word;
+		this.prob = prob;
+	}
+	
+	public String getWord() { return word; }
+	public Float getProb() { return prob; }
+}

--- a/aima-core/src/main/java/aima/core/nlp/parsing/Lexicon.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/Lexicon.java
@@ -1,0 +1,113 @@
+package aima.core.nlp.parsing;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import aima.core.nlp.parsing.grammars.Rule;
+
+/**
+ * The Lexicon Object appears on pg. 891 of the text and defines a simple
+ * set of words for a certain language category and their associated probabilities.
+ * 
+ * Defining and using a lexicon saves us from listing out a large number of rules to
+ * derive terminal strings in a grammar.
+ * 
+ * @author Jonathon
+ *
+ */
+public class Lexicon extends HashMap<String,ArrayList<LexWord>> {
+
+	private static final long serialVersionUID = 1L;
+
+	public ArrayList<Rule> getTerminalRules( String partOfSpeech ) {
+		ArrayList<LexWord> lexWords = this.get(partOfSpeech.toUpperCase());
+		ArrayList<Rule> rules = new ArrayList<Rule>();
+		if( lexWords.size() > 0) {
+			for( int i=0; i < lexWords.size(); i++ ) {
+				rules.add( new Rule( partOfSpeech.toUpperCase(), 
+						   			    lexWords.get(i).word, 
+						   			    lexWords.get(i).prob));
+			}	
+		}
+		return rules;
+	}
+	
+	public ArrayList<Rule> getAllTerminalRules() {
+		ArrayList<Rule> allRules = new ArrayList<Rule>();
+		Set<String> keys = this.keySet();
+		Iterator<String> it = keys.iterator();
+		while( it.hasNext() ) {
+			String key = (String) it.next();
+			allRules.addAll( this.getTerminalRules(key));
+		}
+		
+		return allRules;
+	}
+	
+	public boolean addEntry( String category, String word, float prob ) {
+		if( this.containsKey(category)) {
+			this.get(category).add( new LexWord( word, prob ));
+		}
+		else {
+			this.put(category, new ArrayList<LexWord>( Arrays.asList(new LexWord(word,prob))));
+		}
+		
+		return true;
+	}
+	
+	public boolean addLexWords( String... vargs ) {
+		
+		String key; ArrayList<LexWord> lexWords = new ArrayList<LexWord>();
+		boolean containsKey = false;
+		// number of arguments must be key (1) + lexWord pairs ( x * 2 )
+		if( vargs.length % 2 != 1 ) {
+			return false;
+		}
+		key = vargs[0].toUpperCase();
+		if( this.containsKey(key)) { containsKey = true; }
+			
+		for( int i=1; i < vargs.length; i++ ) {
+			try {
+				if( containsKey ) {
+					this.get(key).add( new LexWord( vargs[i], Float.valueOf(vargs[i+1])));
+				}
+				else {
+					lexWords.add( new LexWord( vargs[i], Float.valueOf(vargs[i+1])));	
+				}
+				i++;
+			} catch( NumberFormatException e ) {
+				System.err.println("Supplied args have incorrect format.");
+				return false;
+			}
+		}
+		if( !containsKey ) { this.put(key, lexWords); }
+		return true;
+		
+	}
+	
+	/**
+	 * Add words to an lexicon from an existing lexicon. Using this 
+	 * you can combine lexicons.
+	 * @param l
+	 */
+	public void addLexWords( Lexicon l ) {
+		Iterator<Map.Entry<String,ArrayList<LexWord>>> it = l.entrySet().iterator();
+		while(it.hasNext()) {
+			Map.Entry<String,ArrayList<LexWord>> pair = it.next();
+			if( this.containsKey( pair.getKey())) {
+				for( int i=0; i < pair.getValue().size(); i++ ) {
+					this.get(pair.getKey()).add(pair.getValue().get(i));
+				}
+			}
+			else {
+				this.put(pair.getKey(), pair.getValue());
+			}
+		}
+	}
+}
+
+

--- a/aima-core/src/main/java/aima/core/nlp/parsing/RunCYK.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/RunCYK.java
@@ -1,0 +1,27 @@
+package aima.core.nlp.parsing;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import aima.core.nlp.data.grammars.ProbCNFGrammarExamples;
+import aima.core.nlp.parsing.grammars.ProbCNFGrammar;
+
+/**
+ * A simple runner class to test out one parsing scenario on CYK.
+ * @author Jonathon
+ *
+ */
+public class RunCYK {
+
+	
+	public static void main(String[] args) {
+		System.out.println("Running...");
+		ProbCNFGrammar exampleG = ProbCNFGrammarExamples.buildTrivialGrammar();
+		CYK cyk = new CYK();
+		List<String> words = new ArrayList<String>(Arrays.asList("the","man","liked","a","woman"));
+		float[][][] probTable = cyk.parse(words, exampleG);
+		cyk.printProbTable(probTable, words, exampleG);
+		System.out.println("Done!");
+	}
+}

--- a/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbCNFGrammar.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbCNFGrammar.java
@@ -1,0 +1,101 @@
+package aima.core.nlp.parsing.grammars;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The CYK algorithm exploits the structure of grammars in 
+ * Chomsky Normal Form in order to parse efficiently. 
+ * 
+ * A context-free grammar is in Chomsky Normal Form (CNF) if each
+ * rule has one of the following forms:
+ * 
+ * 1. A -> BC,
+ * 2. A -> a,
+ * 3. S -> null, where B,C are non-start variables (V - {S}), 
+ * and a is a terminal.
+ * 
+ * @author Jonathon
+ *
+ */
+public class ProbCNFGrammar extends ProbContextFreeGrammar {
+	
+	// TODO: Implement conversion from ContextFree to ChomskyNormalForm
+	
+	// default constructor
+	public ProbCNFGrammar() {
+		type = 4; 
+		rules = new ArrayList<Rule>();
+	}
+	
+	public ProbCNFGrammar( ProbCNFGrammar grammar ) {
+		type = 4;
+		rules = grammar.rules;
+	}
+	
+	/**
+	 * Add a ruleList as the grammar's rule list if all rules in it pass
+	 * both the restrictions of the Context-free grammar, and all rules 
+	 * or in Chomsky-Normal-Form
+	 */
+	public boolean addRules( List<Rule> ruleList ) {
+		for( int i=0; i < ruleList.size(); i++ ) {
+			if( !validRule(ruleList.get(i)) ) {
+				return false;
+			}
+		}
+		if( !validateRuleProbabilities(ruleList)) {
+			return false;
+		}
+		this.rules = ruleList;
+		updateVarsAndTerminals();
+		return true;
+	}
+	
+	/**
+	 * Add a rule to the grammar's rule list if it passes
+	 * both the restrictions of the Context-free grammar, and the rule is
+	 * in Chomsky Normal Form.
+	 */
+	public boolean addRule( Rule r ) {
+		if( !validRule(r) ) {
+			return false;
+		}
+		rules.add(r);
+		updateVarsAndTerminals(r);
+		return true;
+	}
+	
+	/**
+	 * For a grammar rule to be valid in a context-free grammar, 
+	 * all the restrictions of the context-free grammar must hold,
+	 * and the rule must be in one of three forms.
+	 * 
+	 * 1. A -> BC,
+	 * 2. A -> a,
+	 * 3. S -> null, where B,C are non-start variables (V - {S}), 
+	 * and a is a terminal.
+	 * 
+	 * @param r,  a rule
+	 * @return true, if rule is in CNF. false, otherwise
+	 */
+	public boolean validRule( Rule r ){
+		if( !super.validRule(r) ){
+			return false;
+		}
+		// 3. rhs is null
+		if( r.rhs == null || r.rhs.size() == 0) { return true; }
+		// 2. rhs is a terminal (a)
+		else if( r.rhs.size() == 1 && isTerminal(r.rhs.get(0))) {
+			return true;
+		}
+		// 1. rhs is 2 variables (BC)
+		else if( r.rhs.size() == 2 && isVariable(r.rhs.get(0))
+				  && isVariable(r.rhs.get(1))) { 
+			return true;
+		}
+		// rule is not in one of the 3 CNF forms
+		return false;
+	}
+	
+} // end of CNFGrammar()

--- a/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbContextFreeGrammar.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbContextFreeGrammar.java
@@ -1,0 +1,84 @@
+package aima.core.nlp.parsing.grammars;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProbContextFreeGrammar extends ProbContextSensitiveGrammar implements ProbabilisticGrammar {
+	
+	// default constructor
+	public ProbContextFreeGrammar() {
+		type = 2; 
+		rules = null;
+	}
+	
+	/**
+	 * Add a ruleList as the grammar's rule list if all rules in it pass
+	 * both the restrictions of the parent grammars (unrestricted and context-sens)
+	 * and this grammar's restrictions.
+	 */
+	public boolean addRules( List<Rule> ruleList ) {
+		for( int i=0; i < ruleList.size(); i++ ) {
+			if( !super.validRule(ruleList.get(i)) || !validRule(ruleList.get(i)) ) {
+				return false;
+			}
+		}
+		this.rules = ruleList;
+		return true;
+	}
+	
+	/**
+	 * Add a rule to the grammar's rule list if it passes
+	 * both the restrictions of the parent grammars (unrestricted and context-sens)
+	 * and this grammar's restrictions.
+	 */
+	public boolean addRule( Rule r ) {
+		if( !super.validRule(r) || !validRule(r) ) {
+			return false;
+		}
+		rules.add(r);
+		return true;
+	}
+	
+	/**
+	 * For a grammar rule to be valid in a context-free grammar, 
+	 * all the restrictions of the parent grammars must hold, and the restriction
+	 * of the context-free grammar must hold. The restriction is that the lhs must 
+	 * consist of a single non-terminal (variable). There are no restrictions on the rhs
+	 * 
+	 */
+	public boolean validRule( Rule r ){
+		if( !super.validRule(r) ){
+			return false;
+		}
+		// lhs must be a single non-terminal
+		if( r.lhs.size() != 1 || !isVariable(r.lhs.get(0)))
+		{
+			return false;
+		}
+	
+		return true;
+	}
+	
+	/**
+	 * Test whether LHS -> RHS is a rule in the grammar. 
+	 * Note: it must be a DIRECT derivation
+	 * @param lhs
+	 * @param rhs
+	 * @return
+	 */
+	public boolean leftDerivesRight( ArrayList<String> lhs, ArrayList<String> rhs ) {
+		
+		// for each rule in the grammar 
+		for( int i=0; i < rules.size(); i++ ) {
+			Rule r = rules.get(i);
+			if( r.lhs.equals(lhs) && r.rhs.equals(rhs)) {
+				// matching rule found. left does derive the right in this grammar
+				return true;
+			}
+		}
+		// no match found
+		return false;
+	}
+
+
+} // end of ContextFreeGrammar()

--- a/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbContextSensitiveGrammar.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbContextSensitiveGrammar.java
@@ -1,0 +1,75 @@
+package aima.core.nlp.parsing.grammars;
+
+import java.util.ArrayList;
+
+/**
+ * A context-sensitive grammar is less restrictive than context-free and more powerful, but
+ * more restrictive than an unrestricted grammar (an less powerfull).
+ * @author Jonathon
+ *
+ */
+public class ProbContextSensitiveGrammar extends ProbUnrestrictedGrammar implements ProbabilisticGrammar {
+
+	// default constructor
+	public ProbContextSensitiveGrammar() {
+		type = 1; 
+		rules = null;
+	}
+	
+	/**
+	 * Add a ruleList as the grammar's rule list if all rules in it pass
+	 * both the restrictions of the parent grammar (unrestricted) and
+	 * this grammar's restrictions.
+	 */
+	public boolean addRules( ArrayList<Rule> ruleList ) {
+		for( int i=0; i < ruleList.size(); i++ ) {
+			if( !super.validRule(ruleList.get(i)) ) {
+				return false;
+			}
+			if( !validRule(ruleList.get(i)) ) {
+				return false;
+			}
+		}
+		this.rules = ruleList;
+		updateVarsAndTerminals();
+		return true;
+	}
+	
+	/**
+	 * Add a rule to the grammar's rule list if it passes
+	 * both the restrictions of the parent grammar (unrestricted) and
+	 * this grammar's restrictions.
+	 */
+	public boolean addRule( Rule r ) {
+		if( !super.validRule(r) ) {
+			return false;
+		}
+		else if( !validRule(r) ) {
+			return false;
+		}
+		rules.add(r);
+		updateVarsAndTerminals(r);
+		return true;
+	}
+	
+	/**
+	 * For a grammar rule to be valid in a context sensitive grammar, 
+	 * all the restrictions of the parent grammar (unrestricted) must hold, 
+	 * and the number of RHS symbols must be equal or greater than the number
+	 * of LHS symbols.
+	 */
+	public boolean validRule( Rule r ){
+		if( !super.validRule(r) ){
+			return false;
+		}
+		// len(rhs) >= len(lhs) must hold in context-sensitive.
+		else if( r.rhs == null ) {
+			return false;
+		}
+		else if( r.rhs.size() < r.lhs.size() ) {
+			return false;
+		}
+
+		return true;
+	}
+} // end of ContextSensitiveGrammar()

--- a/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbUnrestrictedGrammar.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbUnrestrictedGrammar.java
@@ -1,0 +1,220 @@
+package aima.core.nlp.parsing.grammars;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents the most general grammatical formalism,
+ * the Unrestricted (or Recrusively Enumerable) Grammar.
+ * All other grammars can derive from this grammar, imposing extra
+ * restrictions.
+ * @author Jonathon
+ *
+ */
+public class ProbUnrestrictedGrammar implements ProbabilisticGrammar {
+
+	// types of grammars
+	public static final int UNRESTRICTED = 0;
+	public static final int CONTEXT_SENSITIVE = 1;
+	public static final int	CONTEXT_FREE = 2;
+	public static final int REGULAR = 3;
+	public static final int CNFGRAMMAR = 4;
+	public static final int PROB_CONTEXT_FREE = 5;
+	
+	public List<Rule> rules;
+	public List<String> vars;
+	public List<String> terminals;
+	public int type; 
+	
+	// default constructor. has no rules
+	public ProbUnrestrictedGrammar() {
+		type = 0;
+		rules = new ArrayList<Rule>();
+		vars =  new ArrayList<String>();
+		terminals = new ArrayList<String>();
+	}
+	
+	/**
+	 * Add a number of rules at once, testing each in turn
+	 * for validity, and then testing the batch for probability validity.
+	 * @param ruleList
+	 * @return true if rules are valid and incorporated into the grammar. false, otherwise
+	 */
+	public boolean addRules( List<Rule> ruleList ) {
+		for( int i=0; i < ruleList.size(); i++ ) {
+			if( !validRule(ruleList.get(i)) ) {
+				return false;
+			}
+		}
+		if( !validateRuleProbabilities(ruleList)) {
+			return false;
+		}
+		this.rules = ruleList;
+		updateVarsAndTerminals();
+		return true;
+	}
+	
+	/**
+	 * Add a single rule the grammar, testing it for structural 
+	 * and probability validity.
+	 * @param rule
+	 * @return true if rule is incorporated. false, otherwise
+	 */
+	// TODO: More sophisticated probability distribution management
+	public boolean addRule( Rule rule ) {
+		if( validRule(rule)) {
+			rules.add(rule);
+			updateVarsAndTerminals( rule );
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+	
+	/**
+	 * For a set of rules, test whether each batch of rules with the same 
+	 * LHS have their probabilities sum to exactly 1.0
+	 * @param ruleList
+	 * @return true if the probabilities are valid. false, otherwise
+	 */
+	public boolean validateRuleProbabilities( List<Rule> ruleList ) {
+		float probTotal = 0;
+		for( int i=0; i < vars.size(); i++ ) {
+			for( int j=0; j < ruleList.size(); j++ ) {
+				// reset probTotal at start
+				if( j == 0 ) {
+					probTotal = (float) 0.0;
+				}
+				if( ruleList.get(i).lhs.get(0).equals(vars.get(i))) {
+					probTotal += ruleList.get(i).PROB;
+				}
+				// check probTotal hasn't exceed max
+				if( probTotal > 1.0 ) {
+					return false;
+				}
+				// check we have correct probability total
+				if( j == ruleList.size() -1 && probTotal != (float) 1.0 ) {
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+	
+	/**
+	 * Test validity of the LHS and RHS of grammar rule.
+	 * In unrestricted grammar, the only invalid rule type is
+	 * a rule with a null LHS.
+	 * @param r ( a rule )
+	 * @return true, if rule has valid form. false, otherwise
+	 */
+	public boolean validRule( Rule r ) {
+		if( r.lhs != null && r.lhs.size() > 0 ) {
+			return true;
+		}
+		else {
+			return false;
+		}
+	}
+	
+	/** 
+	 * Whenever a new rule is added to the grammar, we want to 
+	 * update the list of variables and terminals with any new grammar symbols
+	 */
+	public void updateVarsAndTerminals() {
+		if( rules == null ) {
+			vars =  new ArrayList<String>();
+			terminals = new ArrayList<String>();
+			return;
+		}
+		for( int i=0; i < rules.size(); i++ ) {
+			Rule r = rules.get(i);
+			updateVarsAndTerminals(r);	// update the variables and terminals for this rule
+		}
+	}
+	
+	/**
+	 * Update variable and terminal lists with a single rule's symbols,
+	 * if there a new symbols
+	 * @param r
+	 */
+	public void updateVarsAndTerminals( Rule r ) {
+		// check lhs for new terminals or variables
+		for( int j=0; j < r.lhs.size(); j++ ) {
+			if( isVariable(r.lhs.get(j)) && !vars.contains(r.lhs.get(j))) {
+				vars.add(r.lhs.get(j));
+			}
+			else if( isTerminal(r.lhs.get(j)) && !terminals.contains(r.lhs.get(j))) {
+				terminals.add(r.lhs.get(j));
+			}
+		}
+		// for rhs we must check that this isn't a null-rule
+		if ( r.rhs != null ) {
+			// check rhs for new terminals or variables
+			for( int j=0; j < r.rhs.size(); j++ ) {
+				if( isVariable(r.rhs.get(j)) && !vars.contains(r.rhs.get(j))) {
+					vars.add(r.rhs.get(j));
+				}
+				else if( isTerminal(r.rhs.get(j)) && !terminals.contains(r.rhs.get(j))) {
+					terminals.add(r.rhs.get(j));
+				}
+			}
+		}
+		// maintain sorted lists
+		Collections.sort(vars);
+		Collections.sort(terminals);
+	}
+	
+	
+	/**
+	 * Check if we have a variable, as they are uppercase strings.
+	 * @param s
+	 * @return
+	 */
+	public static boolean isVariable(String s) {
+		for (int i=0; i < s.length(); i++)
+		{
+			if (!Character.isUpperCase(s.charAt(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	/** 
+	 * Check if we have a terminal, as they are lowercase strings
+	 * @param s
+	 * @return true, if string must be a terminal. false, otherwise
+	 */
+	public static boolean isTerminal(String s) {
+		for (int i=0; i < s.length(); i++ ) {
+			
+			if( !Character.isLowerCase(s.charAt(i))) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	
+	@Override
+	public String toString() {
+		String output = "";
+		output += "Variables:  ";
+		for( int i=0; i < this.vars.size(); i++ ) {
+			output+= this.vars.get(i) + ", ";
+		}
+		output+= '\n';
+		output += "Terminals:  ";
+		for( int i=0; i < this.terminals.size(); i++ ) {
+			output+= this.terminals.get(i) + ", ";
+		}
+		output+= '\n';
+		for( int i=0; i < this.rules.size(); i++ ) {
+			output += this.rules.get(i).toString() + '\n';
+		}
+		return output;
+	}
+}

--- a/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbabilisticGrammar.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/grammars/ProbabilisticGrammar.java
@@ -1,0 +1,18 @@
+package aima.core.nlp.parsing.grammars;
+
+import java.util.List;
+
+public interface ProbabilisticGrammar {
+	
+	public boolean addRules( List<Rule> ruleList );
+	
+	public boolean addRule( Rule r );
+	
+	public boolean validRule( Rule r );
+	
+	public boolean validateRuleProbabilities( List<Rule> ruleList );
+	
+	public void updateVarsAndTerminals( Rule r );
+	
+	public void updateVarsAndTerminals();
+}

--- a/aima-core/src/main/java/aima/core/nlp/parsing/grammars/Rule.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/grammars/Rule.java
@@ -1,0 +1,95 @@
+package aima.core.nlp.parsing.grammars;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A derivation rule that is contained within a grammar. This rule is probabilistic, in that it 
+ * has an associated probability representing the likelihood that the RHS follows from the LHS, given 
+ * the presence of the LHS.
+ * @author Jonathon (thundergolfer)
+ *
+ */
+public class Rule {
+	
+	public final float PROB;
+	public final List<String> lhs; // Left hand side of derivation rule
+	public final List<String> rhs; // Right hand side of derivation rule
+	
+	// Basic constructor
+	public Rule( List<String> lhs, List<String> rhs, float probability ) {
+		this.lhs = lhs;
+		this.rhs = rhs;
+		this.PROB = validateProb( probability );
+	}
+	
+	// null RHS rule constructor
+	public Rule( List<String> lhs, float probability ) {
+		this.lhs = lhs;
+		this.rhs = null;
+		this.PROB = validateProb( probability );
+	}
+	
+	// string split constructor
+	public Rule( String lhs, String rhs, float probability) {
+		if( lhs.equals("")) {
+			this.lhs = new ArrayList<String>();
+		} else {
+			this.lhs = new ArrayList<String>(Arrays.asList(lhs.split("\\s*,\\s*")));
+		}
+		if( rhs.equals("")) {
+			this.rhs = new ArrayList<String>();
+		} else {
+			this.rhs = new ArrayList<String>(Arrays.asList(rhs.split("\\s*,\\s*")));
+		}
+		this.PROB = validateProb( probability );
+		
+	}
+	
+	/**
+	 * Currently a hack to ensure rule has a valid probablity value.
+	 * Don't really want to throw an exception.
+	 */
+	private float validateProb(float prob) {
+		if( prob >= 0.0 && prob <= 1.0 ) {
+			return prob;
+		}
+		else {
+			return (float) 0.5; // probably should throw exception
+		}
+	}
+	
+	public boolean derives( List<String> sentForm ) {
+		if( this.rhs.size() != sentForm.size() ) {
+			return false;
+		}
+		for( int i=0; i < sentForm.size(); i++ ) {
+			if( this.rhs.get(i) != sentForm.get(i)) {
+				return false;
+			}
+		}
+		return true;
+	}
+	
+	public boolean derives( String terminal ) {
+		if( this.rhs.size() == 1 && this.rhs.get(0).equals(terminal)) {
+			return true;
+		}
+		return false;
+	}
+	
+	@Override 
+	public String toString() {
+		String output = "";
+		for( int i=0; i < lhs.size(); i++) {
+			output += lhs.get(i);
+		}
+		output += " -> ";
+		for( int i=0; i < rhs.size(); i++) {
+			output += rhs.get(i);
+		}	
+		output += " " + String.valueOf(PROB);
+		return output;
+	}
+}

--- a/aima-core/src/test/java/aima/test/core/unit/nlp/parse/CYKParseTest.java
+++ b/aima-core/src/test/java/aima/test/core/unit/nlp/parse/CYKParseTest.java
@@ -1,0 +1,42 @@
+package aima.test.core.unit.nlp.parse;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import aima.core.nlp.data.grammars.ProbCNFGrammarExamples;
+import aima.core.nlp.parsing.CYK;
+import aima.core.nlp.parsing.grammars.ProbCNFGrammar;
+
+public class CYKParseTest {
+
+	CYK parser;
+	ArrayList<String> words1; ArrayList<String> words2;
+	ProbCNFGrammar trivGrammar = ProbCNFGrammarExamples.buildTrivialGrammar();
+	// Get Example Grammar 2
+	
+	@Before
+	public void setUp() {
+		parser = new CYK();
+		words1 = new ArrayList<String>( Arrays.asList("the","man","liked","a","woman"));
+		
+	} // end setUp()
+	
+	@Test
+	public void testParseReturn() {
+		float[][][] probTable = null;
+	    probTable = parser.parse( words1, trivGrammar );
+		assertNotNull( probTable );
+	}
+	
+	@Test
+	public void testParse() {
+		float[][][] probTable;
+		probTable = parser.parse(words1, trivGrammar);
+		assertTrue( probTable[5][0][4] > 0); // probTable[5,0,4] = [S][Start=0][Length=5] 
+	}
+}

--- a/aima-core/src/test/java/aima/test/core/unit/nlp/parse/GrammarTest.java
+++ b/aima-core/src/test/java/aima/test/core/unit/nlp/parse/GrammarTest.java
@@ -1,0 +1,100 @@
+package aima.test.core.unit.nlp.parse;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import aima.core.nlp.parsing.grammars.ProbUnrestrictedGrammar;
+import aima.core.nlp.parsing.grammars.Rule;
+
+public class GrammarTest {
+	
+	ProbUnrestrictedGrammar g; ProbUnrestrictedGrammar g2;
+	
+	@Before
+	public void setup() {
+		g = new ProbUnrestrictedGrammar(); // reset grammar before each test
+	}
+
+	@Test
+	public void testValidRule() {
+		Rule invalidR = new Rule( null, new ArrayList<String>(Arrays.asList("W","Z")),(float)0.5);
+		Rule validR   = new Rule( new ArrayList<String>(Arrays.asList("W")), 
+								  new ArrayList<String>(Arrays.asList("a","s")),(float)0.5);
+		Rule validR2  = new Rule( new ArrayList<String>(Arrays.asList("W")), null, (float)0.5);
+		assertFalse( g.validRule(invalidR));
+		assertTrue(  g.validRule(validR));
+		assertTrue(  g.validRule(validR2));
+		
+	}
+	
+	/**
+	 * Grammar should not allow a rule of the form 
+	 * null -> X, where X is a combo of variables and terminals
+	 */
+	@Test
+	public void testRejectNullLhs() {
+		Rule r = new Rule( new ArrayList<String>() , new ArrayList<String>(), (float)0.50); // test completely null rule
+		// test only null lhs
+		Rule r2 = new Rule( null, new ArrayList<String>(Arrays.asList("W","Z")),(float)0.50);
+		assertFalse( g.addRule(r));
+		assertFalse( g.addRule(r2));
+	}
+	
+	/**
+	 * Grammar (unrestricted) should accept all the rules in the test,
+	 * as they have non-null left hand sides
+	 */
+	@Test
+	public void testAcceptValidRules() {
+		Rule unrestrictedRule = new Rule( new ArrayList<String>(Arrays.asList("A","a","A","B")),
+										  new ArrayList<String>(Arrays.asList("b","b","A","C")),(float)0.50);
+		Rule contextSensRule =  new Rule( new ArrayList<String>(Arrays.asList("A","a","A")),
+				  						  new ArrayList<String>(Arrays.asList("b","b","A","C")),(float)0.50);
+		Rule contextFreeRule = new Rule( new ArrayList<String>(Arrays.asList("A")),
+				  						  new ArrayList<String>(Arrays.asList("b","b","A","C")),(float)0.50);
+		Rule regularRule     = new Rule( new ArrayList<String>(Arrays.asList("A")),
+				  						 new ArrayList<String>(Arrays.asList("b","C")),(float)0.50);
+		Rule nullRHSRule     = new Rule( new ArrayList<String>(Arrays.asList("A","B")), null ,(float)0.50);
+		// try adding these rules in turn
+		assertTrue( g.addRule( unrestrictedRule ));
+		assertTrue( g.addRule( contextSensRule  ));
+		assertTrue( g.addRule( contextFreeRule  ));
+		assertTrue( g.addRule( regularRule      ));
+		assertTrue( g.addRule( nullRHSRule      ));
+	}
+	
+	/**
+	 * Test that Grammar class correctly updates its 
+	 * list of variables and terminals when a new rule is added
+	 */
+	@Test 
+	public void testUpdateVarsAndTerminals() {
+		// add a rule that has variables and terminals not 
+		// already in the grammar
+		g.addRule( new Rule( new ArrayList<String>(Arrays.asList("Z")),
+					 		  new ArrayList<String>(Arrays.asList("z","Z")),(float)0.50));
+		assertTrue( g.terminals.contains("z") && !g.terminals.contains("Z"));
+		assertTrue( g.vars.contains("Z") && !g.vars.contains("z"));
+	}
+	
+	@Test
+	public void testIsVariable() {
+		assertTrue(  ProbUnrestrictedGrammar.isVariable("S"));
+		assertTrue(  ProbUnrestrictedGrammar.isVariable("SSSSS"));
+		assertFalse( ProbUnrestrictedGrammar.isVariable("s"));
+		assertFalse( ProbUnrestrictedGrammar.isVariable("tttt"));
+	}
+	
+	@Test
+	public void testIsTerminal() {
+		assertTrue(  ProbUnrestrictedGrammar.isTerminal("x"));
+		assertTrue(  ProbUnrestrictedGrammar.isTerminal("xxxxx"));
+		assertFalse( ProbUnrestrictedGrammar.isTerminal("X"));
+		assertFalse( ProbUnrestrictedGrammar.isTerminal("XXXXXX"));
+	}
+}

--- a/aima-core/src/test/java/aima/test/core/unit/nlp/parse/LexiconTest.java
+++ b/aima-core/src/test/java/aima/test/core/unit/nlp/parse/LexiconTest.java
@@ -1,0 +1,90 @@
+package aima.test.core.unit.nlp.parse;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import aima.core.nlp.data.lexicons.LexiconExamples;
+import aima.core.nlp.parsing.Lexicon;
+import aima.core.nlp.parsing.grammars.Rule;
+
+public class LexiconTest {
+
+	Lexicon l;
+	Lexicon wumpusLex;
+	
+	@Before
+	public void setUp() {
+		l = new Lexicon();
+		wumpusLex = LexiconExamples.buildWumpusLex();
+	}
+	
+	@Test
+	public void testAddEntry() {
+		l.addEntry("EXAMPLE", "word", (float)0.10);
+		assertTrue( l.containsKey("EXAMPLE"));
+		assertEquals( l.get("EXAMPLE").size(), 1 );
+	}
+	
+	@Test
+	public void testAddEntryExistingCategory() {
+		l.addEntry("EXAMPLE", "word", (float)0.10);
+		l.addEntry("EXAMPLE", "second", (float)0.90);
+		assertTrue( l.containsKey("EXAMPLE"));
+		assertTrue( l.keySet().size() == 1 );
+		assertTrue( l.get("EXAMPLE").get(1).getWord().equals("second"));
+
+	}
+	
+	@Test
+	public void testAddLexWords() {
+		String key = "EXAMPLE";
+		l.addLexWords( key, "stench", "0.05", "breeze", "0.10", "wumpus", "0.15");
+		assertTrue( l.get(key).size() == 3);
+		assertTrue( l.get(key).get(0).getWord().equals("stench"));
+		
+	}
+	
+	@Test
+	public void testAddLexWordsWithInvalidArgs() {
+		String key = "EXAMPLE";
+		assertFalse( l.addLexWords( key, "stench", "0.05", "breeze"));
+		assertFalse( l.containsKey(key));
+	}
+	
+	@Test 
+	public void testGetTerminalRules() {
+		String key1 = "A"; String key2 = "B"; String key3 = "C";
+		l.addLexWords(key1, "apple","0.25","alpha","0.5","arrow","0.25");
+		l.addLexWords(key2, "ball","0.25","bench","0.25","blue","0.25","bell","0.25");
+		l.addLexWords(key3, "carrot","0.25","canary","0.5","caper","0.25");
+		ArrayList<Rule> rules1 = l.getTerminalRules(key1);
+		ArrayList<Rule> rules2 = l.getTerminalRules(key2);
+		ArrayList<Rule> rules3 = l.getTerminalRules(key3);
+		assertEquals( rules1.size(), 3 );
+		assertEquals( rules1.get(0).rhs.get(0), "apple");
+		assertEquals( rules2.size(), 4 );
+		assertEquals( rules2.get(3).rhs.get(0), "bell");
+		assertEquals( rules3.size(), 3);
+		assertEquals( rules3.get(1).lhs.get(0), "C");
+	}
+	
+	@Test 
+	public void testGetAllTerminalRules() {
+		String key1 = "A"; String key2 = "B"; String key3 = "C";
+		l.addLexWords(key1, "apple","0.25","alpha","0.5","arrow","0.25");
+		l.addLexWords(key2, "ball","0.25","bench","0.25","blue","0.25","bell","0.25");
+		l.addLexWords(key3, "carrot","0.25","canary","0.5","caper","0.25");
+		ArrayList<Rule> allRules = l.getAllTerminalRules();
+		assertEquals( allRules.size(), 10 );
+		assertTrue( allRules.get(0).rhs.get(0).equals("apple") ||
+					allRules.get(0).rhs.get(0).equals("ball") ||
+					allRules.get(0).rhs.get(0).equals("carrot"));
+	}
+	
+	
+
+}

--- a/aima-core/src/test/java/aima/test/core/unit/nlp/parse/ProbCNFGrammarTest.java
+++ b/aima-core/src/test/java/aima/test/core/unit/nlp/parse/ProbCNFGrammarTest.java
@@ -1,0 +1,52 @@
+package aima.test.core.unit.nlp.parse;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import aima.core.nlp.data.grammars.ProbContextFreeExamples;
+import aima.core.nlp.parsing.grammars.ProbCNFGrammar;
+import aima.core.nlp.parsing.grammars.ProbContextFreeGrammar;
+import aima.core.nlp.parsing.grammars.Rule;
+
+/**
+ * Test the class representing the Chomsky Normal Form grammar
+ * @author Jonathon
+ *
+ */
+public class ProbCNFGrammarTest {
+
+	ProbCNFGrammar gEmpty;
+	Rule validR; Rule invalidR;
+	
+	@Before
+	public void setUp() {
+		gEmpty = new ProbCNFGrammar();
+		validR = new Rule( new ArrayList<String>(Arrays.asList("A")),
+				new ArrayList<String>(Arrays.asList("Y","X")),(float)0.50);
+		invalidR = new Rule( new ArrayList<String>(Arrays.asList("A")),
+				  new ArrayList<String>(Arrays.asList("Y","X","Z")),(float)0.50); // too many RHS variables
+	}
+	
+	@Test
+	public void testAddValidRule() {
+		assertTrue(gEmpty.addRule(validR));
+	}
+	
+	@Test
+	public void testAddInvalidRule() {
+		assertFalse(gEmpty.addRule(invalidR));
+	}
+	
+	@Test
+	public void testValidRule() {
+		assertTrue( gEmpty.validRule(validR));
+		assertFalse( gEmpty.validRule(invalidR));
+	}
+	
+
+}

--- a/aima-core/src/test/java/aima/test/core/unit/nlp/parse/ProbContextFreeGrammarTest.java
+++ b/aima-core/src/test/java/aima/test/core/unit/nlp/parse/ProbContextFreeGrammarTest.java
@@ -1,0 +1,37 @@
+package aima.test.core.unit.nlp.parse;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import aima.core.nlp.data.grammars.ProbContextFreeExamples;
+import aima.core.nlp.parsing.grammars.ProbUnrestrictedGrammar;
+import aima.core.nlp.parsing.grammars.Rule;
+
+public class ProbContextFreeGrammarTest {
+
+	ProbUnrestrictedGrammar g;
+	ProbUnrestrictedGrammar cfG;
+	
+	@Before
+	public void setup() {
+		g = new ProbUnrestrictedGrammar();
+		cfG = ProbContextFreeExamples.buildWumpusGrammar();
+	}
+	
+	@Test
+	public void testValidRule() {
+		// This rule is a valid Context-Free rule
+		Rule validR   = new Rule( new ArrayList<String>(Arrays.asList("W")), 
+								  new ArrayList<String>(Arrays.asList("a","s")), (float)0.5);
+		// This rule is of correct form but not a context-free rule
+		Rule invalidR  = new Rule( new ArrayList<String>(Arrays.asList("W","A")), null , (float)0.5);
+		assertFalse( cfG.validRule(invalidR));
+		assertTrue(  cfG.validRule(validR));
+	}
+
+}

--- a/aima-core/src/test/java/aima/test/core/unit/nlp/parse/RuleTest.java
+++ b/aima-core/src/test/java/aima/test/core/unit/nlp/parse/RuleTest.java
@@ -1,0 +1,42 @@
+package aima.test.core.unit.nlp.parse;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import aima.core.nlp.parsing.grammars.Rule;
+
+public class RuleTest {
+
+	Rule testR;
+	
+	@Test
+	public void testStringSplitConstructor() {
+		testR = new Rule("A,B", "a,bb,c", (float)0.50);
+		assertEquals( testR.lhs.size(), 2 );
+		assertEquals( testR.rhs.size(), 3 );
+		assertEquals( testR.lhs.get(1), "B");
+		assertEquals( testR.rhs.get(2), "c");
+	}
+	
+	@Test 
+	public void testStringSplitConstructorOnEmptyStrings() {
+		testR = new Rule("", "",(float)0.50);
+		assertEquals( testR.lhs.size(), 0);
+		assertEquals( testR.rhs.size(), 0);
+	}
+	
+	@Test
+	public void testStringSplitConstructorOnCommas() {
+		testR = new Rule(",", ",",(float)0.50);
+		assertEquals( testR.lhs.size(), 0);
+		assertEquals( testR.rhs.size(), 0);
+	}
+	
+	@Test( expected=IndexOutOfBoundsException.class)
+	public void testStringSplitConstructorElementAccess() {
+		testR = new Rule(",", "",(float)0.50);
+		testR.lhs.get(0);
+	}
+
+}


### PR DESCRIPTION
I have implemented the CYK Algorithm from the book as faithfully as I could. 

The CYK Algorithm runs in RunCYK.java on a simple Chomsky Normal Form Grammar, if you would like to see a demonstration.

The Wumpus Grammar from the textbook has also been included as an example grammar, but note that it is a ContextFree Grammar and not a Chomsky Normal Form Grammar. In order to use the Wumpus Grammar with CYK some conversion needs to be performed. I will add this conversion code in a later commit. 
