### PR TITLE
Add Priority Queue to GraphPriorityQueueSearch and TreePriorityQueueSearch

### DIFF
--- a/extra/src/main/java/aima/extra/search/pqueue/AbstractQueueSearchForActions.java
+++ b/extra/src/main/java/aima/extra/search/pqueue/AbstractQueueSearchForActions.java
@@ -1,10 +1,6 @@
 package aima.extra.search.pqueue;
 
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Supplier;
 
 import aima.core.search.api.Node;
@@ -101,8 +97,16 @@ public abstract class AbstractQueueSearchForActions<A, S> implements QueueSearch
 		return frontier;
 	}
 
-	public boolean loopDo() {
-		return getSearchController().isExecuting();
+    public PriorityQueue<Node<A, S>> newFrontierPriority(Node<A, S> initialNode, Comparator<Node<A, S>> comparator) {
+        PriorityQueue<Node<A, S>> frontier = new PriorityQueue<>();
+        frontier.add(initialNode);
+        // Track if this is supported by the underlying implementation
+        frontierSupportsStateContainmentCheck = frontier.contains(initialNode.state());
+        return frontier;
+    }
+
+    public boolean loopDo() {
+        return getSearchController().isExecuting();
 	}
 
 	public Set<S> newExploredSet() {
@@ -129,10 +133,10 @@ public abstract class AbstractQueueSearchForActions<A, S> implements QueueSearch
 		return frontier.contains(state);
 	}
 
-	public boolean removedNodeFromFrontierWithSameStateAndLowerPriority(Node<A, S> child, Queue<Node<A, S>> frontier) {
-		// NOTE: Not very efficient (i.e. linear in the size of the frontier)
-		// NOTE: by Java's PriorityQueue convention, nodes that compare lower
-		// (i.e. cost) have a higher priority.
-		return frontier.removeIf(n -> child.state().equals(n.state()) && getNodeComparator().compare(child, n) < 0);
-	}
+    public boolean removedNodeFromFrontierWithSameStateAndLowerPriority(Node<A, S> child, PriorityQueue<Node<A, S>> pqFrontier) {
+        // NOTE: Not very efficient (i.e. linear in the size of the frontier)
+        // NOTE: by Java's PriorityQueue convention, nodes that compare lower
+        // (i.e. cost) have a higher priority.
+        return pqFrontier.removeIf(n -> child.state().equals(n.state()));
+    }
 }

--- a/extra/src/main/java/aima/extra/search/pqueue/AbstractQueueSearchForActions.java
+++ b/extra/src/main/java/aima/extra/search/pqueue/AbstractQueueSearchForActions.java
@@ -1,8 +1,13 @@
 package aima.extra.search.pqueue;
 
-import java.util.*;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.PriorityQueue;
 import java.util.function.Supplier;
-
+import java.util.Comparator;
 import aima.core.search.api.Node;
 import aima.core.search.api.NodeFactory;
 import aima.core.search.api.Problem;

--- a/extra/src/main/java/aima/extra/search/pqueue/uninformed/GraphPriorityQueueSearch.java
+++ b/extra/src/main/java/aima/extra/search/pqueue/uninformed/GraphPriorityQueueSearch.java
@@ -1,6 +1,7 @@
 package aima.extra.search.pqueue.uninformed;
 
 import java.util.List;
+import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 
@@ -45,19 +46,19 @@ public class GraphPriorityQueueSearch<A, S> extends AbstractQueueSearchForAction
 		// node <- a node with STATE = problem.INITIAL-STATE
 		Node<A, S> node = newRootNode(problem.initialState());
 		// frontier <- a priority queue, with node as the only element
-		Queue<Node<A, S>> frontier = newFrontier(node);
-		// explored <- an empty set
+        PriorityQueue<Node<A, S>> pqFrontier = newFrontierPriority(node, getNodeComparator());
+        // explored <- an empty set
 		Set<S> explored = newExploredSet();
 		// loop do
 		while (loopDo()) {
 			// if EMPTY?(frontier) then return failure
-			if (frontier.isEmpty()) {
-				return failure();
+            if (pqFrontier.isEmpty()) {
+                return failure();
 			}
 			// node <- POP(frontier) // chooses the highest priority node in
 			// frontier
-			node = frontier.remove();
-			// if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
+            node = pqFrontier.remove();
+            // if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
 			if (isGoalState(node, problem)) {
 				return solution(node);
 			}
@@ -68,16 +69,16 @@ public class GraphPriorityQueueSearch<A, S> extends AbstractQueueSearchForAction
 				// child <- CHILD-NODE(problem, node, action)
 				Node<A, S> child = newChildNode(problem, node, action);
 				// if child.STATE is not in explored or frontier then
-				boolean childStateInFrontier = containsState(frontier, child.state());
-				if (!(childStateInFrontier || explored.contains(child.state()))) {
+                boolean childStateInFrontier = containsState(pqFrontier, child.state());
+                if (!(childStateInFrontier || explored.contains(child.state()))) {
 					// frontier <- INSERT(child, frontier)
-					frontier.add(child);
-				} // else if child.STATE is in frontier with lower priority then
+                    pqFrontier.add(child);
+                } // else if child.STATE is in frontier with lower priority then
 				else if (childStateInFrontier
-						&& removedNodeFromFrontierWithSameStateAndLowerPriority(child, frontier)) {
-					// replace that frontier node with child
-					frontier.add(child);
-				}
+                        && removedNodeFromFrontierWithSameStateAndLowerPriority(child, pqFrontier)) {
+                    // replace that frontier node with child
+                    pqFrontier.add(child);
+                }
 			}
 		}
 		return failure();

--- a/extra/src/main/java/aima/extra/search/pqueue/uninformed/TreePriorityQueueSearch.java
+++ b/extra/src/main/java/aima/extra/search/pqueue/uninformed/TreePriorityQueueSearch.java
@@ -1,6 +1,7 @@
 package aima.extra.search.pqueue.uninformed;
 
 import java.util.List;
+import java.util.PriorityQueue;
 import java.util.Queue;
 
 import aima.core.search.api.Node;
@@ -42,16 +43,16 @@ public class TreePriorityQueueSearch<A, S> extends AbstractQueueSearchForActions
 		// node <- a node with STATE = problem.INITIAL-STATE
 		Node<A, S> node = newRootNode(problem.initialState());
 		// frontier <- a priority queue, with node as the only element
-		Queue<Node<A, S>> frontier = newFrontier(node);
+		PriorityQueue<Node<A, S>> pqFrontier = newFrontierPriority(node, getNodeComparator());
 		// loop do
 		while (loopDo()) {
 			// if EMPTY?(frontier) then return failure
-			if (frontier.isEmpty()) {
+			if (pqFrontier.isEmpty()) {
 				return failure();
 			}
 			// node <- POP(frontier) // chooses the highest priority node in
 			// frontier
-			node = frontier.remove();
+			node = pqFrontier.remove();
 			// if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
 			if (isGoalState(node, problem)) {
 				return solution(node);
@@ -61,15 +62,15 @@ public class TreePriorityQueueSearch<A, S> extends AbstractQueueSearchForActions
 				// child <- CHILD-NODE(problem, node, action)
 				Node<A, S> child = newChildNode(problem, node, action);
 				// if child.STATE is not in frontier then
-				boolean childStateInFrontier = containsState(frontier, child.state());
+				boolean childStateInFrontier = containsState(pqFrontier, child.state());
 				if (!childStateInFrontier) {
 					// frontier <- INSERT(child, frontier)
-					frontier.add(child);
+					pqFrontier.add(child);
 				} // else if child.STATE is in frontier with lower priority then
 				else if (childStateInFrontier
-						&& removedNodeFromFrontierWithSameStateAndLowerPriority(child, frontier)) {
+						&& removedNodeFromFrontierWithSameStateAndLowerPriority(child, pqFrontier)) {
 					// replace that frontier node with child
-					frontier.add(child);
+					pqFrontier.add(child);
 				}
 			}
 		}


### PR DESCRIPTION
Goals :-
1. Priority queue improves readability for graph and tree algorithms as mentioned in the description of the algorithm.
1. Prevents many calls to function ``getNodeComparator().compare(child, n)`` in `` removedNodeFromFrontierWithSameStateAndLowerPriority() ``.