### PR TITLE
Optimise UniformCostSearch algorithm.

### DIFF
--- a/core/src/main/java/aima/core/search/basic/uninformed/UniformCostSearch.java
+++ b/core/src/main/java/aima/core/search/basic/uninformed/UniformCostSearch.java
@@ -1,6 +1,12 @@
 package aima.core.search.basic.uninformed;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.Set;
+import java.util.HashMap;
 
 import aima.core.search.api.Node;
 import aima.core.search.api.NodeFactory;

--- a/core/src/main/java/aima/core/search/basic/uninformed/UniformCostSearch.java
+++ b/core/src/main/java/aima/core/search/basic/uninformed/UniformCostSearch.java
@@ -1,17 +1,13 @@
 package aima.core.search.basic.uninformed;
 
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.PriorityQueue;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 
 import aima.core.search.api.Node;
 import aima.core.search.api.NodeFactory;
 import aima.core.search.api.Problem;
 import aima.core.search.api.SearchController;
 import aima.core.search.api.SearchForActionsFunction;
+import aima.core.search.basic.support.BasicFrontierQueue;
 import aima.core.search.basic.support.BasicNodeFactory;
 import aima.core.search.basic.support.BasicSearchController;
 
@@ -104,7 +100,7 @@ public class UniformCostSearch<A, S> implements SearchForActionsFunction<A, S> {
 	}
 
 	public Queue<Node<A, S>> newPriorityQueueOrderedByPathCost(Node<A, S> initialNode) {
-		Queue<Node<A, S>> frontier = new PriorityQueue<>(Comparator.comparingDouble(Node::pathCost));
+		Queue<Node<A, S>> frontier = new BasicFrontierQueue<A,S>(() -> new PriorityQueue<>(Comparator.comparingDouble(Node::pathCost)), HashMap::new);
 		frontier.add(initialNode);
 		return frontier;
 	}
@@ -122,8 +118,7 @@ public class UniformCostSearch<A, S> implements SearchForActionsFunction<A, S> {
 	}
 
 	public boolean containsState(Queue<Node<A, S>> frontier, S state) {
-		// NOTE: Not very efficient (i.e. linear in the size of the frontier)
-		return frontier.stream().anyMatch(frontierNode -> frontierNode.state().equals(state));
+		return frontier.contains(state);
 	}
 
 	public boolean removedNodeFromFrontierWithSameStateAndHigherPathCost(Node<A, S> child, Queue<Node<A, S>> frontier) {

--- a/test/src/test/java/aima/test/unit/search/uninformed/UniformCostSearchTest.java
+++ b/test/src/test/java/aima/test/unit/search/uninformed/UniformCostSearchTest.java
@@ -1,15 +1,11 @@
 package aima.test.unit.search.uninformed;
 
 import aima.core.environment.map2d.GoAction;
-import aima.core.environment.map2d.InState;
 import aima.core.environment.map2d.SimplifiedRoadMapOfPartOfRomania;
 import aima.core.environment.support.ProblemFactory;
-import aima.core.search.api.BidirectionalActions;
 import aima.core.search.api.Problem;
 import aima.core.search.api.SearchForActionsFunction;
-import aima.core.search.basic.uninformed.BidirectionalSearch;
 import aima.core.search.basic.uninformed.UniformCostSearch;
-import aima.core.util.datastructure.Pair;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/test/src/test/java/aima/test/unit/search/uninformed/UniformCostSearchTest.java
+++ b/test/src/test/java/aima/test/unit/search/uninformed/UniformCostSearchTest.java
@@ -1,0 +1,51 @@
+package aima.test.unit.search.uninformed;
+
+import aima.core.environment.map2d.GoAction;
+import aima.core.environment.map2d.InState;
+import aima.core.environment.map2d.SimplifiedRoadMapOfPartOfRomania;
+import aima.core.environment.support.ProblemFactory;
+import aima.core.search.api.BidirectionalActions;
+import aima.core.search.api.Problem;
+import aima.core.search.api.SearchForActionsFunction;
+import aima.core.search.basic.uninformed.BidirectionalSearch;
+import aima.core.search.basic.uninformed.UniformCostSearch;
+import aima.core.util.datastructure.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * @author manthan.
+ */
+@RunWith(Parameterized.class)
+public class UniformCostSearchTest {
+    @Parameterized.Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> implementations() {
+        return Arrays.asList(new Object[][]{{"UniformCostSearch"}});
+    }
+
+    @Parameterized.Parameter
+    public String searchFunctionName;
+
+    public <A, S> List<A> searchForActions(Problem<A, S> problem) {
+        SearchForActionsFunction<A, S> searchForActionsFunction = new UniformCostSearch<>();
+        return searchForActionsFunction.apply(problem);
+    }
+
+    @Test
+    public void testBidirectionalSearch() {
+        Assert.assertEquals(
+                Arrays.asList(new GoAction(SimplifiedRoadMapOfPartOfRomania.SIBIU),
+                        new GoAction(SimplifiedRoadMapOfPartOfRomania.RIMNICU_VILCEA),
+                        new GoAction(SimplifiedRoadMapOfPartOfRomania.PITESTI),
+                        new GoAction(SimplifiedRoadMapOfPartOfRomania.BUCHAREST)),
+                searchForActions(ProblemFactory.getSimplifiedRoadMapOfPartOfRomaniaProblem(
+                        SimplifiedRoadMapOfPartOfRomania.ARAD, SimplifiedRoadMapOfPartOfRomania.BUCHAREST)));
+    }
+
+}


### PR DESCRIPTION
The aim of the PR is to optimise UniformCostSearch algorithm.
1. Linear time check for state containment is replaced by the built in queue containment and ```BasicFrontierQueue``` is used with underlying Priority queue implementation and hasmap.
1. Use of ```AbstractPriorityQueueSearchForActions``` and ```QueueSearchForActions``` would have been better but i refrained from doing so to prevent circular dependence between core and extra modules.
1. I have written a separate test class, it can be merged with other test class as well.