### PR TITLE
Removed Redundant Modifiers Fixes #284

### DIFF
--- a/aima-core/src/main/java/aima/core/environment/nqueens/NQueensBoard.java
+++ b/aima-core/src/main/java/aima/core/environment/nqueens/NQueensBoard.java
@@ -16,7 +16,7 @@ import aima.core.util.datastructure.XYLocation;
 public class NQueensBoard {
 
 	/** Parameters for initialization. */
-	public static enum Config {
+	public enum Config {
 		EMPTY, QUEENS_IN_FIRST_ROW, QUEEN_IN_EVERY_COL
 	};
 

--- a/aima-core/src/main/java/aima/core/environment/wumpusworld/AgentPosition.java
+++ b/aima-core/src/main/java/aima/core/environment/wumpusworld/AgentPosition.java
@@ -22,7 +22,7 @@ public class AgentPosition {
 		
 		private final String name;
 		
-		private Orientation(String name) {
+		Orientation(String name) {
 			this.name = name;
 		}
 	}

--- a/aima-core/src/main/java/aima/core/logic/propositional/parsing/ast/Connective.java
+++ b/aima-core/src/main/java/aima/core/logic/propositional/parsing/ast/Connective.java
@@ -136,7 +136,7 @@ public enum Connective {
 	private final String symbol;
 	private final int precedence;
 
-	private Connective(String symbol, int precedence) {
+	Connective(String symbol, int precedence) {
 		this.symbol = symbol;
 		this.precedence = precedence;
 	}

--- a/aima-gui/src/main/java/aima/gui/fx/framework/SimulationPaneCtrl.java
+++ b/aima-gui/src/main/java/aima/gui/fx/framework/SimulationPaneCtrl.java
@@ -24,7 +24,7 @@ import javafx.scene.input.MouseButton;
  */
 public class SimulationPaneCtrl {
 
-	public static enum State {
+	public enum State {
 		READY, RUNNING, FINISHED, PAUSED, CANCELED
 	}
 

--- a/aima-gui/src/main/java/aima/gui/swing/applications/agent/map/RouteFindingAgentApp.java
+++ b/aima-gui/src/main/java/aima/gui/swing/applications/agent/map/RouteFindingAgentApp.java
@@ -53,7 +53,7 @@ public class RouteFindingAgentApp extends SimpleAgentApp {
 	protected static class RouteFindingAgentFrame extends MapAgentFrame {
 		private static final long serialVersionUID = 1L;
 
-		public static enum MapType {
+		public enum MapType {
 			ROMANIA, AUSTRALIA
 		};
 


### PR DESCRIPTION
I have removed most of the instances of redundant modifiers across the codebase. I have made the changes with references to [this](http://stackoverflow.com/questions/3664077/why-cant-enum-constructors-be-protected-or-public-in-java) , [this](http://stackoverflow.com/questions/36286178/java-enum-constructors-private) and [this](http://stackoverflow.com/questions/253226/nested-java-enum-definition-does-declaring-as-static-make-a-difference).

Thank You :smile: 