### PR TITLE
Optimality of AStarSearch 

### DIFF
--- a/core/src/main/java/aima/core/search/basic/informed/AStarSearch.java
+++ b/core/src/main/java/aima/core/search/basic/informed/AStarSearch.java
@@ -71,11 +71,13 @@ public class AStarSearch<A, S> implements SearchForActionsFunction<A, S> {
 				if (!(explored.contains(child.state()) || containsState(frontier, child.state()))) {
 					// frontier <- INSERT(child, frontier)
 					frontier.add(child);
-				} // else if child.STATE is in frontier with higher COST then
+				} 
+				//optimality of A*
+				/*// else if child.STATE is in frontier with higher COST then
 				else if (removedNodeFromFrontierWithSameStateAndHigherCost(child, frontier)) {
 					// replace that frontier node with child
 					frontier.add(child);
-				}
+				}*/
 			}
 		}
 	}

--- a/core/src/main/java/aima/core/search/basic/uninformed/BidirectionalSearch.java
+++ b/core/src/main/java/aima/core/search/basic/uninformed/BidirectionalSearch.java
@@ -24,11 +24,11 @@ import java.util.Queue;
  * <pre>
  * The strategy of this search implementation is inspired by the description of
  * the bidirectional search algorithm i.e. Problem is reversed and search is performed from both
- * frontiers.
+ * frontiers. The logic used in traversal is breadth first search.
  * @author manthan
  */
 public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionallyFunction<A, S> {
-    private BidirectionalActions<A> bidirectionalActions;
+	private BidirectionalActions<A> bidirectionalActions;
     private List<A> fromInitialStatePartList = new ArrayList<>();
     private List<A> fromGoalStatePartList = new ArrayList<>();
     private Node<A, S> previousMeetingOfTwoFrontiers;
@@ -38,22 +38,37 @@ public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionall
     @Override
 
     public BidirectionalActions<A> apply(Problem<A, S> originalProblem, Problem<A, S> reverseProblem) {
-        Node<A, S> node = newRootNode(originalProblem.initialState(), 0);
+        Node<A, S> node = newRootNode(originalProblem.initialState(), 0); //node -> starting point 
+        //if starting node is the goal node then return bidirectionalAction 
+        //which is the solution of the problem (total cost -> zero)
+        //First terminating condition
         if (originalProblem.isGoalState(node.state())) {
             this.previousMeetingOfTwoFrontiers = node;
             this.nextNodeToBeEvaluated = null;
             bidirectionalActions = new BasicBidirectionalActions<>(fromInitialStatePart(), fromGoalStatePart());
             return bidirectionalActions;
         }
-        Node<A, S> revNode = newRootNode(reverseProblem.initialState(), 0);
+        
+        Node<A, S> revNode = newRootNode(reverseProblem.initialState(), 0);//revNode -> goal node
+        //front -> priority queue which has node to be explored when traversing from starting node
         Queue<Node<A, S>> front = newFIFOQueue(node);
+        //back -> priority queue which has node to be explored when traversing from goal node
         Queue<Node<A, S>> back = newFIFOQueue(revNode);
+        //exploredFront -> map which has explored nodes marked when traversing from starting node 
         Map<S, Node<A, S>> exploredFront = newExploredMap(node.state());
+        //exploredBack -> map which has explored nodes marked when traversing from goal node
         Map<S, Node<A, S>> exploredBack = newExploredMap(revNode.state());
 
+        //while both the priority queue (i.e. front and back) are filled then that implies
+        //there is a path from both the end hence we traverse from both the end till we meet in the middle
+        //otherwise there is no solution
+        
+        //a loop is run till solution is found or 
+        //failure is reported
         while (!front.isEmpty() && !back.isEmpty()) {
-
+        	
             // Existence of path is checked from both ends of the problem.
+        	
             if (isSolution(pathExistsBidirectional(front, exploredFront, exploredBack, originalProblem), true)) {
                 bidirectionalActions = new BasicBidirectionalActions<>(fromInitialStatePart(), fromGoalStatePart());
                 return bidirectionalActions;
@@ -63,45 +78,80 @@ public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionall
                 return bidirectionalActions;
             }
         }
+        //when anyone of the priority queue gets empty
+        //return failure (i.e. no path found)
         this.previousMeetingOfTwoFrontiers = null;
         bidirectionalActions = new BasicBidirectionalActions<>(fromInitialStatePart(), fromGoalStatePart());
         return bidirectionalActions;
     }
-
+    
+    //checking whether there is a path from the given side
     private Node<A, S> pathExistsBidirectional(Queue<Node<A, S>> queue, Map<S, Node<A, S>> exploredFront, Map<S, Node<A, S>> exploredBack, Problem<A, S> problem) {
-        if (!queue.isEmpty()) {
+        //queue -> any one of the priority queue (i.e. front or back)
+    	//exploredFront -> map which has explored nodes marked when traversing from starting node
+    	//exploredBack -> map which has explored nodes marked when traversing from goal node
+    	
+    	//problem contains information about the 
+    	//initial state, action that is to be performed, goal test, path cost and result function
+    	//which gives the result of the action 
+    	
+    	//if queue is not empty then there is a node to be explored
+    	if (!queue.isEmpty()) {
+    		//exploring the first node in the queue
+    		//next -> first node from queue
             Node<A, S> next = queue.remove();
+            //performing the action on next
+            //till its all child has not been explored
             for (A action : problem.actions(next.state())) {
+            	//checking every child of next whether it can be used in the path or not
                 Node<A, S> child = newChildNode(problem, next, action);
+                //if child node is in exploredBack map
                 if (exploredBack.containsKey(child.state())) {
+                	//child node is found in exploredBack
+                	//meeting point of two frontiers
                     this.previousMeetingOfTwoFrontiers = next;
                     this.nextNodeToBeEvaluated = exploredBack.get(child.state());
                     return child;
                 }
+                //if child node is not contained in any one of the map and queue
+            	//then perform following action
                 if (!(exploredFront.containsKey(child.state()) || queue.contains(child.state()))) {
+                	
+                	//check if it is a goal state
                     if (problem.isGoalState(child.state())) {
+                    	//setting meeting point -> next node
                         this.previousMeetingOfTwoFrontiers = next;
                         this.nextNodeToBeEvaluated = exploredBack.get(child.state());
                         return child;
                     }
+                    
+                    //every child is added into exploredFront who is not in it already
+                    //this is to overcome the self loop
                     exploredFront.put(child.state(), next);
+                    //child node is added in queue so that 
+                    //action can be performed on its every child 
                     queue.add(child);
                 }
             }
         }
+    	//if queue is empty return null (i.e. failure)
         this.previousMeetingOfTwoFrontiers = null;
         return null;
     }
 
     private boolean isSolution(Node<A, S> solutionNode, boolean fromFront) {
+    	//solutionNode is a node which is checked whether it is a meeting of two frontiers or not
+    	//if solutionNode is not null 
         if (solutionNode != null) {
+        	//then it is the meeting of the two frontiers
             this.meetingOfTwoFrontiers = solutionNode;
             this.fromFront = fromFront;
             return true;
         }
+        //else it is not a meeting point
         return false;
     }
-    //
+    
     //Supporting Code
     protected NodeFactory<A, S> nodeFactory = new BasicNodeFactory<>();
     protected SearchController<A, S> searchController = new BasicSearchController<>();

--- a/core/src/main/java/aima/core/search/basic/uninformed/BidirectionalSearch.java
+++ b/core/src/main/java/aima/core/search/basic/uninformed/BidirectionalSearch.java
@@ -24,7 +24,7 @@ import java.util.Queue;
  * <pre>
  * The strategy of this search implementation is inspired by the description of
  * the bidirectional search algorithm i.e. Problem is reversed and search is performed from both
- * frontiers. The logic used in traversal is breadth first search.
+ * frontiers.
  * @author manthan
  */
 public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionallyFunction<A, S> {
@@ -38,37 +38,22 @@ public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionall
     @Override
 
     public BidirectionalActions<A> apply(Problem<A, S> originalProblem, Problem<A, S> reverseProblem) {
-        Node<A, S> node = newRootNode(originalProblem.initialState(), 0); //node -> starting point 
-        //if starting node is the goal node then return bidirectionalAction 
-        //which is the solution of the problem (total cost -> zero)
-        //First terminating condition
+        Node<A, S> node = newRootNode(originalProblem.initialState(), 0);
         if (originalProblem.isGoalState(node.state())) {
             this.previousMeetingOfTwoFrontiers = node;
             this.nextNodeToBeEvaluated = null;
             bidirectionalActions = new BasicBidirectionalActions<>(fromInitialStatePart(), fromGoalStatePart());
             return bidirectionalActions;
         }
-        
-        Node<A, S> revNode = newRootNode(reverseProblem.initialState(), 0);//revNode -> goal node
-        //front -> priority queue which has node to be explored when traversing from starting node
+        Node<A, S> revNode = newRootNode(reverseProblem.initialState(), 0);
         Queue<Node<A, S>> front = newFIFOQueue(node);
-        //back -> priority queue which has node to be explored when traversing from goal node
         Queue<Node<A, S>> back = newFIFOQueue(revNode);
-        //exploredFront -> map which has explored nodes marked when traversing from starting node 
         Map<S, Node<A, S>> exploredFront = newExploredMap(node.state());
-        //exploredBack -> map which has explored nodes marked when traversing from goal node
         Map<S, Node<A, S>> exploredBack = newExploredMap(revNode.state());
 
-        //while both the priority queue (i.e. front and back) are filled then that implies
-        //there is a path from both the end hence we traverse from both the end till we meet in the middle
-        //otherwise there is no solution
-        
-        //a loop is run till solution is found or 
-        //failure is reported
         while (!front.isEmpty() && !back.isEmpty()) {
-        	
+
             // Existence of path is checked from both ends of the problem.
-        	
             if (isSolution(pathExistsBidirectional(front, exploredFront, exploredBack, originalProblem), true)) {
                 bidirectionalActions = new BasicBidirectionalActions<>(fromInitialStatePart(), fromGoalStatePart());
                 return bidirectionalActions;
@@ -78,80 +63,45 @@ public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionall
                 return bidirectionalActions;
             }
         }
-        //when anyone of the priority queue gets empty
-        //return failure (i.e. no path found)
         this.previousMeetingOfTwoFrontiers = null;
         bidirectionalActions = new BasicBidirectionalActions<>(fromInitialStatePart(), fromGoalStatePart());
         return bidirectionalActions;
     }
-    
-    //checking whether there is a path from the given side
+
     private Node<A, S> pathExistsBidirectional(Queue<Node<A, S>> queue, Map<S, Node<A, S>> exploredFront, Map<S, Node<A, S>> exploredBack, Problem<A, S> problem) {
-        //queue -> any one of the priority queue (i.e. front or back)
-    	//exploredFront -> map which has explored nodes marked when traversing from starting node
-    	//exploredBack -> map which has explored nodes marked when traversing from goal node
-    	
-    	//problem contains information about the 
-    	//initial state, action that is to be performed, goal test, path cost and result function
-    	//which gives the result of the action 
-    	
-    	//if queue is not empty then there is a node to be explored
-    	if (!queue.isEmpty()) {
-    	    //exploring the first node in the queue
-    	    //next -> first node from queue
+        if (!queue.isEmpty()) {
             Node<A, S> next = queue.remove();
-            //performing the action on next
-            //till its all child has not been explored
             for (A action : problem.actions(next.state())) {
-            	//checking every child of next whether it can be used in the path or not
                 Node<A, S> child = newChildNode(problem, next, action);
-                //if child node is in exploredBack map
                 if (exploredBack.containsKey(child.state())) {
-                    //child node is found in exploredBack
-                    //meeting point of two frontiers
                     this.previousMeetingOfTwoFrontiers = next;
                     this.nextNodeToBeEvaluated = exploredBack.get(child.state());
                     return child;
                 }
-                //if child node is not contained in any one of the map and queue
-            	//then perform following action
                 if (!(exploredFront.containsKey(child.state()) || queue.contains(child.state()))) {
-                	
-                    //check if it is a goal state
                     if (problem.isGoalState(child.state())) {
-                    	//setting meeting point -> next node
                         this.previousMeetingOfTwoFrontiers = next;
                         this.nextNodeToBeEvaluated = exploredBack.get(child.state());
                         return child;
                     }
-                    
-                    //every child is added into exploredFront who is not in it already
-                    //this is to overcome the self loop
                     exploredFront.put(child.state(), next);
-                    //child node is added in queue so that 
-                    //action can be performed on its every child 
                     queue.add(child);
                 }
             }
         }
-    	//if queue is empty return null (i.e. failure)
         this.previousMeetingOfTwoFrontiers = null;
         return null;
     }
 
     private boolean isSolution(Node<A, S> solutionNode, boolean fromFront) {
-    	//solutionNode is a node which is checked whether it is a meeting of two frontiers or not
-    	//if solutionNode is not null 
         if (solutionNode != null) {
-            //then it is the meeting of the two frontiers
             this.meetingOfTwoFrontiers = solutionNode;
             this.fromFront = fromFront;
             return true;
         }
-        //else it is not a meeting point
         return false;
     }
-    
+    //
     //Supporting Code
     protected NodeFactory<A, S> nodeFactory = new BasicNodeFactory<>();
     protected SearchController<A, S> searchController = new BasicSearchController<>();

--- a/core/src/main/java/aima/core/search/basic/uninformed/BidirectionalSearch.java
+++ b/core/src/main/java/aima/core/search/basic/uninformed/BidirectionalSearch.java
@@ -28,7 +28,7 @@ import java.util.Queue;
  * @author manthan
  */
 public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionallyFunction<A, S> {
-	private BidirectionalActions<A> bidirectionalActions;
+    private BidirectionalActions<A> bidirectionalActions;
     private List<A> fromInitialStatePartList = new ArrayList<>();
     private List<A> fromGoalStatePartList = new ArrayList<>();
     private Node<A, S> previousMeetingOfTwoFrontiers;
@@ -97,8 +97,8 @@ public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionall
     	
     	//if queue is not empty then there is a node to be explored
     	if (!queue.isEmpty()) {
-    		//exploring the first node in the queue
-    		//next -> first node from queue
+    	    //exploring the first node in the queue
+    	    //next -> first node from queue
             Node<A, S> next = queue.remove();
             //performing the action on next
             //till its all child has not been explored
@@ -107,8 +107,8 @@ public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionall
                 Node<A, S> child = newChildNode(problem, next, action);
                 //if child node is in exploredBack map
                 if (exploredBack.containsKey(child.state())) {
-                	//child node is found in exploredBack
-                	//meeting point of two frontiers
+                    //child node is found in exploredBack
+                    //meeting point of two frontiers
                     this.previousMeetingOfTwoFrontiers = next;
                     this.nextNodeToBeEvaluated = exploredBack.get(child.state());
                     return child;
@@ -117,7 +117,7 @@ public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionall
             	//then perform following action
                 if (!(exploredFront.containsKey(child.state()) || queue.contains(child.state()))) {
                 	
-                	//check if it is a goal state
+                    //check if it is a goal state
                     if (problem.isGoalState(child.state())) {
                     	//setting meeting point -> next node
                         this.previousMeetingOfTwoFrontiers = next;
@@ -143,7 +143,7 @@ public class BidirectionalSearch<A, S> implements SearchForActionsBidirectionall
     	//solutionNode is a node which is checked whether it is a meeting of two frontiers or not
     	//if solutionNode is not null 
         if (solutionNode != null) {
-        	//then it is the meeting of the two frontiers
+            //then it is the meeting of the two frontiers
             this.meetingOfTwoFrontiers = solutionNode;
             this.fromFront = fromFront;
             return true;


### PR DESCRIPTION
Part of the book
Optimality of A*
As we mentioned earlier, A* has the following properties: the tree-search version of A* is optimal if h(n) is admissible, while the graph-search version is optimal if h(n) is consistent. 
We show the second of these two claims since it is more useful. The argument essentially mirrors the argument for the optimality of uniform-cost search, with g replaced by f—just as in the A* algorithm itself.
The first step is to establish the following: if h(n) is consistent, then the values of f(n) along any path are nondecreasing. The proof follows directly from the definition of consistency. Suppose n' is a successor of n; then g(n')=g(n) + c(n, a, n') for some action a, and we have 
f(n') = g(n') + h(n') = g(n) + c(n, a, n') + h(n') ≥ g(n) + h(n) = f(n) .
The next step is to prove that whenever A* selects a node n for expansion, the optimal path to that node has been found. Were this not the case, there would have to be another frontier node n' on the optimal path from the start node to n, by the graph separation property of Figure 3.9; because f is nondecreasing along any path, n' would have lower f-cost than n and would have been selected first.
![figure 3 9](https://cloud.githubusercontent.com/assets/14966081/24567948/7ae41028-167d-11e7-8d7d-4366b3f2c0fd.PNG)
