### PR TITLE
Added Graphplan implementation (Figure 10.9)

### DIFF
--- a/aima-core/src/main/java/aima/core/logic/fol/domain/DomainFactory.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/domain/DomainFactory.java
@@ -90,4 +90,16 @@ public class DomainFactory {
 		domain.addConstant("Drew");
 		return domain;
 	}
+
+	public static FOLDomain spareTireDomain() {
+		FOLDomain domain = new FOLDomain();
+		domain.addConstant("Spare");
+		domain.addConstant("Flat");
+		domain.addConstant("Axle");
+		domain.addConstant("Trunk");
+		domain.addConstant("Ground");
+
+		domain.addPredicate("At");
+		return domain;
+	}
 }

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/GraphPlan.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/GraphPlan.java
@@ -1,0 +1,475 @@
+package aima.core.logic.fol.inference.graphplan;
+
+import aima.core.logic.fol.kb.data.CNF;
+import aima.core.logic.fol.kb.data.Clause;
+import aima.core.logic.fol.kb.data.Literal;
+import aima.core.util.datastructure.LabeledGraph;
+import aima.core.util.datastructure.Pair;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Artificial Intelligence A Modern Approach (3rd Edition): page 383.<br>
+ * <br>
+ *
+ * <pre>
+ * <code>
+ * function GraphPlan(problem) returns solution or failure
+ *
+ *   graph &larr; INITIAL-PLANNING-GRAPH(problem)
+ *   goals &larr; CONJUNCTS(problem.GOAL)
+ *   nogoods &larr; an empty hash table
+ *   for tl = 0 to &infin; do
+ *       if goals all non-mutex in S<sub>t</sub> of graph then
+ *           solution &larr; EXTRACT-SOLUTION(graph, goals, NUMLEVELS(graph), nogoods)
+ *           if solution &ne; failure then return solution
+ *       if graph and nogoods have both leveled off then return failure
+ *       graph &larr; EXPAND-GRAPH(graph, problem)
+ * </code>
+ * </pre>
+ *
+ * Figure 10.9 The GraphPlan algorithm. GraphPlan calls Expand-Graph to add a
+ * level until either a solution is found by Extract-Solution, or no solution is possible.
+ *
+ * @author Matt Grenander
+ */
+public class GraphPlan {
+    /**
+     * function GraphPlan(problem) returns solution or failure
+     *
+     * @param problem
+     *               provides a PDDL description of the problem
+     * @return a list of actions describing a solution for the given problem or
+     *         null if no solution is found (i.e failure)
+     */
+    public List<PDDLAction> graphPlan(PDDL problem) {
+
+        // graph &larr; INITIAL-PLANNING-GRAPH(problem)
+        LabeledGraph<GraphPlanNode,MutexLink> graph = initialPlanningGraph(problem);
+        // goals &larr; CONJUNCTS(problem.GOAL)
+        List<Literal> goals = conjuncts(problem.getGoal());
+        // nogoods &larr; an empty hash table
+        HashSet<Pair<Integer,List<Literal>>> nogoods = new HashSet<>();
+
+        // for tl = 0 to &infin; do
+        for(int t = 0; true; t++) {
+            // if goals all non-mutex in S<sub>t</sub> of graph then
+            if(allNonMutex(goals,graph,t)) {
+                // solution &larr; EXTRACT-SOLUTION(graph, goals, NUMLEVELS(graph), nogoods)
+                List<PDDLAction> solution = solutionExtractor.extractSolution(graph,goals,numLevels(graph),nogoods);
+                // if solution &ne; failure then return solution
+                if(solution != null) { return solution; }
+            }
+
+            // if graph and nogoods have both leveled off then return failure
+            if(haveLeveledOff(graph,nogoods,goals)) { return null; }
+
+            // graph &larr; EXPAND-GRAPH(graph, problem)
+            graph = expandGraph(graph,problem);
+        }
+    }
+
+    //
+    //SUPPORTING CODE
+    private SolutionExtractor solutionExtractor = null;
+
+    /**
+     * Constructor for GraphPlan
+     * @param solutionExtractor
+     *                           object that will extract a solution from a planning graph
+     */
+    public GraphPlan(SolutionExtractor solutionExtractor) {
+        this.solutionExtractor = solutionExtractor;
+    }
+
+    /**
+     * Initialize the planning graph given a PDDL problem description
+     * @param problem
+     *                 a PDDL object that describes the problem statement
+     * @return the initial planning graph for the problem
+     */
+    private static LabeledGraph<GraphPlanNode,MutexLink> initialPlanningGraph(PDDL problem) {
+        List<Literal> literals = CNFToLiteral(problem.getInit());
+        LabeledGraph<GraphPlanNode,MutexLink> graph = new LabeledGraph<>();
+        for (Literal literal: literals) {
+            graph.addVertex(new PlanGraphState(0,literal));
+        }
+        return graph;
+    }
+
+    /**
+     * Returns a list of simpler sentences from a goal sentence in CNF form
+     * @param goal
+     *             the CNF goal sentence
+     * @return a list of Literals from the CNF goal, or null if goal is null
+     */
+    private static List<Literal> conjuncts(CNF goal) {
+        if (goal == null) {
+            return null;
+        }
+
+        List<Clause> clauseGoals = goal.getConjunctionOfClauses();
+        ArrayList<Literal> literalGoals = new ArrayList<>(goal.getNumberOfClauses());
+        for (Clause clause: clauseGoals) { //Each clause is a unit clause
+            literalGoals.add((Literal)clause.getLiterals().toArray()[0]);
+        }
+        return literalGoals;
+    }
+
+    /**
+     * Checks if all the goal vertices appear at level t in the planning graph and are non-mutex
+     * @param goals
+     *              List of goal literals
+     * @param graph
+     *              Planning graph
+     * @param t
+     *              The number of levels in the graph
+     * @return boolean indicating if all goals are non-mutex or not
+     */
+    private static boolean allNonMutex(List<Literal> goals, LabeledGraph<GraphPlanNode,MutexLink> graph, int t) {
+        //Find all vertices at level S_t
+        List<GraphPlanNode> vertices = graph.getVertexLabels();
+        List<GraphPlanNode> validVertices = new ArrayList<>();
+        List<Literal> validLiterals = new ArrayList<>();
+
+        for (GraphPlanNode vertex: vertices) {
+            //If the level is at t AND the state type is state AND the vertex is contained in goals, we add the vertex to validVertices
+            if (vertex.getLevel() == t && vertex instanceof PlanGraphState && goals.contains(((PlanGraphState) vertex).getLiteral())) {
+                validVertices.add(vertex);
+                validLiterals.add(((PlanGraphState) vertex).getLiteral());
+            }
+        }
+
+        //Check if all goals are at level S_t
+        for (Literal goal: goals) {
+            if (!validLiterals.contains(goal)) {
+                return false;
+            }
+        }
+
+        //Check if all goals are non-mutex
+        for (GraphPlanNode v1: validVertices) {
+            for (GraphPlanNode v2: validVertices) {
+                if (!v1.equals(v2)) { //If the vertices are the same we continue
+                    MutexLink edge = graph.get(v1,v2);
+                    if (edge != null && edge == MutexLink.MUTEX) { //The edge is mutex. Return false.
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the number of levels in our graph
+     * @param graph
+     *               graph to search
+     * @return the deepest level in the graph
+     */
+    static int numLevels(LabeledGraph<GraphPlanNode,MutexLink> graph) {
+        List<GraphPlanNode> vertices = graph.getVertexLabels();
+        int maxLevel = 0;
+
+        for (GraphPlanNode vertex: vertices) {
+           maxLevel = Math.max(maxLevel, vertex.getLevel());
+        }
+        return maxLevel;
+    }
+
+    /**
+     * Check if the graph and no-goods have both leveled off
+     * @param graph
+     *                The planning graph.
+     * @param nogoods
+     *                The no-goods Hashtable.
+     * @return true if they have both leveled off, false otherwise
+     */
+    private static boolean haveLeveledOff(LabeledGraph<GraphPlanNode,MutexLink> graph, HashSet<Pair<Integer,List<Literal>>> nogoods, List<Literal> goals) {
+        //Get max level in graph
+        int maxLevel = numLevels(graph);
+        if (maxLevel <= 1) { //Not possible to determine if the graph has leveled off yet
+            return false;
+        }
+
+        //Check if graph has leveled off
+        boolean hasGraphLeveledOff = graphLeveledOff(graph,maxLevel);
+
+        //Check if no-goods has leveled off
+        boolean hasNoGoodsLeveledOff = noGoodsLeveledOff(nogoods, maxLevel, goals);
+
+        return hasGraphLeveledOff && hasNoGoodsLeveledOff;
+    }
+
+    //Checks if graph has leveled off. Helper method for haveLeveledOff method.
+    private static boolean graphLeveledOff(LabeledGraph<GraphPlanNode,MutexLink> graph, int maxLevel) {
+        //Get all vertices at level maxLevel and maxLevel - 1
+        List<GraphPlanNode> allVertices = graph.getVertexLabels();
+        Set<Literal> newLevelLiterals = new HashSet<>();
+        Set<Literal> oldLevelLiterals = new HashSet<>();
+
+        Set<PDDLAction> newLevelActions = new HashSet<>();
+        Set<PDDLAction> oldLevelActions = new HashSet<>();
+
+        for (GraphPlanNode vertex: allVertices) {
+            int vertexLevel = vertex.getLevel();
+            if (vertexLevel == maxLevel - 1) {
+                if (vertex instanceof PlanGraphState) {
+                    newLevelLiterals.add(((PlanGraphState) vertex).getLiteral());
+                } else if (vertex instanceof  PlanGraphAction){
+                    newLevelActions.add(((PlanGraphAction) vertex).getAction());
+                }
+            } else if (vertexLevel == maxLevel - 2) {
+                if (vertex instanceof PlanGraphState) {
+                    oldLevelLiterals.add(((PlanGraphState) vertex).getLiteral());
+                } else if (vertex instanceof  PlanGraphAction){
+                    oldLevelActions.add(((PlanGraphAction) vertex).getAction());
+                }
+            }
+        }
+
+        //Check if the vertices are all the same.
+        //Note that these are STATE and ACTION states.
+        return newLevelLiterals.equals(oldLevelLiterals) && oldLevelActions.equals(newLevelActions);
+    }
+
+    //Checks if no-goods has leveled off. Helper method for haveLeveledOff method.
+    private static boolean noGoodsLeveledOff(HashSet<Pair<Integer,List<Literal>>> nogoods, int maxLevel, List<Literal> goals) {
+        boolean containsOld = false;
+        boolean containsNew = false;
+        for (Pair<Integer,List<Literal>> pair: nogoods) {
+            if (pair.getSecond().equals(goals)) {
+                if (pair.getFirst().equals(maxLevel)) {
+                    containsNew = true;
+                } else if (pair.getFirst().equals(maxLevel - 1)) {
+                    containsOld = true;
+                }
+            }
+        }
+        return containsOld && containsNew;
+    }
+
+    /**
+     * Expands the planning graph one level (one action level, followed by one state level)
+     * @param graph
+     *                the initial planning graph
+     * @param problem
+     *                a PDDL description of the problem
+     * @return the same planning graph, expanded one level further
+     */
+    private static LabeledGraph<GraphPlanNode,MutexLink> expandGraph(LabeledGraph<GraphPlanNode,MutexLink> graph, PDDL problem) {
+        int currLevel = numLevels(graph);
+        addActionLevel(graph,problem,currLevel);
+        addStateLevel(graph,currLevel);
+        return graph;
+    }
+
+    //Helper method for expandGraph. Adds new PlanGraphAction level.
+    private static void addActionLevel(LabeledGraph<GraphPlanNode,MutexLink> graph, PDDL problem, int currLevel) {
+        //Find actions that have their preconditions satisfied
+        List<GraphPlanNode> vertices = graph.getVertexLabels();
+        List<Literal> currLiterals = new ArrayList<>();
+        for (GraphPlanNode vertex: vertices) {
+            if (vertex.getLevel() == currLevel && vertex instanceof PlanGraphState) {
+                currLiterals.add(((PlanGraphState) vertex).getLiteral());
+            }
+        }
+
+        List<PDDLAction> actionSchema = problem.getActions();
+        List<PlanGraphAction> newActions = new ArrayList<>();
+        for (PDDLAction action: actionSchema) {
+            //See if preconditions are satisfied for this action
+            List<Literal> precondLiterals = CNFToLiteral(action.getPrecond());
+
+            if (currLiterals.containsAll(precondLiterals)) {
+                PlanGraphAction v = new PlanGraphAction(currLevel,action);
+                graph.addVertex(v);
+                newActions.add(v);
+
+                //Add links between new action vertices and old states
+                for (Literal precondLiteral: precondLiterals) {
+                    graph.set(v, findStateVertex(currLevel,precondLiteral,graph), MutexLink.NONMUTEX);
+                }
+            }
+        }
+
+        //Add mutex links
+        if (newActions.isEmpty()) { //No new actions
+            return;
+        }
+
+        for (PlanGraphAction v1: newActions) {
+            inner:for (PlanGraphAction v2: newActions) {
+                if (!v1.equals(v2)) {
+                    List<Literal> v1Effects = CNFToLiteral(v1.getAction().getEffect());
+                    List<Literal> v2Effects = CNFToLiteral(v2.getAction().getEffect());
+                    List<Literal> v1Precond = CNFToLiteral(v1.getAction().getPrecond());
+                    List<Literal> v2Precond = CNFToLiteral(v2.getAction().getPrecond());
+
+                    //Condition 1: Inconsistent effects
+                    for (Literal e1: v1Effects) {
+                        for (Literal e2: v2Effects) {
+                            if (e1.isNegativeOf(e2)) {
+                                graph.set(v1,v2,MutexLink.MUTEX);
+                                continue inner;
+                            }
+                        }
+                    }
+
+                    //Condition 2: Interference
+                    for (Literal e1: v1Effects) {
+                        for (Literal p2: v2Precond) {
+                            if (e1.isNegativeOf(p2)) {
+                                graph.set(v1,v2,MutexLink.MUTEX);
+                                continue inner;
+                            }
+                        }
+                    }
+
+                    for (Literal e2: v2Effects) {
+                        for (Literal p1: v1Precond) {
+                            if (e2.isNegativeOf(p1)) {
+                                graph.set(v1,v2,MutexLink.MUTEX);
+                                continue inner;
+                            }
+                        }
+                    }
+
+                    //Condition 3: Competing needs
+                    for (Literal p1: v1Precond) {
+                        for (Literal p2: v2Precond) {
+                            //See if previous level contains the two preconditions
+                            if (currLiterals.contains(p1) && currLiterals.contains(p2)) {
+                                //See if they are mutex
+                                MutexLink edge = graph.get(findStateVertex(currLevel,p1,graph),findStateVertex(currLevel,p2,graph));
+                                if (edge != null && edge == MutexLink.MUTEX) {
+                                    graph.set(v1,v2,MutexLink.MUTEX);
+                                    continue inner;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    //Helper method for expandGraph. Adds new PlanGraphState level.
+    private static void addStateLevel(LabeledGraph<GraphPlanNode,MutexLink> graph, int currLevel) {
+        //Get new actions states
+        List<GraphPlanNode> vertices = graph.getVertexLabels();
+        List<PlanGraphAction> newActionStates = new ArrayList<>();
+        for (GraphPlanNode vertex: vertices) {
+            if (vertex.getLevel() == currLevel && vertex instanceof PlanGraphAction) {
+                newActionStates.add((PlanGraphAction)vertex);
+            }
+        }
+
+        //Add effects of new actions
+        List<PlanGraphState> newStates = new ArrayList<>();
+        for (PlanGraphAction newActionState: newActionStates) {
+            List<Literal> effects = CNFToLiteral(newActionState.getAction().getEffect());
+            for(Literal effect: effects) {
+                if (findStateVertex(currLevel+1,effect,graph) == null) { //Don't add the same vertex twice
+                    PlanGraphState newState = new PlanGraphState(currLevel+1,effect);
+                    graph.addVertex(newState);
+                    newStates.add(newState);
+                }
+            }
+        }
+
+        //Add no-ops
+        List<PlanGraphState> noOps = new ArrayList<>();
+        for (GraphPlanNode vertex: vertices) {
+            if (vertex.getLevel() == currLevel && vertex instanceof PlanGraphState) {
+                if (findStateVertex(currLevel+1,((PlanGraphState) vertex).getLiteral(),graph) == null) {
+                    PlanGraphState newVertex = new PlanGraphState(currLevel+1,((PlanGraphState) vertex).getLiteral());
+                    noOps.add(newVertex);
+                    newStates.add(newVertex);
+                }
+            }
+        }
+
+        for (PlanGraphState noOp: noOps) {
+            graph.addVertex(noOp);
+        }
+
+        //Add mutex between new literals
+        for (PlanGraphState v1: newStates) {
+            for (PlanGraphState v2: newStates) {
+                if(!v1.equals(v2)) {
+                    Literal l1 = v1.getLiteral();
+                    Literal l2 = v2.getLiteral();
+
+                    //Condition 1: Negation of another
+                    if (l1.isNegativeOf(l2)) {
+                        graph.set(v1,v2,MutexLink.MUTEX);
+                        continue;
+                    }
+
+                    //Condition 2: Inconsistent support
+                    List<PlanGraphAction> v1Actions = new ArrayList<>();
+                    List<PlanGraphAction> v2Actions = new ArrayList<>();
+                    for (PlanGraphAction newActionState: newActionStates) {
+                        List<Literal> effects = CNFToLiteral(newActionState.getAction().getEffect());
+                        if (effects.contains(l1)) {
+                            v1Actions.add(newActionState);
+                        } else if (effects.contains(l2)) {
+                            v2Actions.add(newActionState);
+                        }
+                    }
+
+                    //Check if v1Actions and v2Actions have any non-mutex links
+                    boolean inconsistent = true;
+                    outer:for (PlanGraphAction a1: v1Actions) {
+                        for (PlanGraphAction a2: v2Actions) {
+                            if (!a1.equals(a2) && graph.get(a1,a2) == null) {
+                                inconsistent = false;
+                                break outer;
+                            }
+                        }
+                    }
+
+                    if(inconsistent) { //Add mutex link
+                        graph.set(v1,v2,MutexLink.MUTEX);
+                    }
+                }
+            }
+        }
+    }
+
+    //Converts CNF to a more useful list of literals
+    static List<Literal> CNFToLiteral(CNF cnf) {
+        List<Clause> clauses = cnf.getConjunctionOfClauses();
+        List<Literal> literals = new ArrayList<>();
+        for (Clause clause: clauses) {
+            if (clause.isUnitClause()) {
+                literals.add((Literal)clause.getLiterals().toArray()[0]);
+            } else if (clause.getNumberLiterals() == 0) { //Empty clause
+                return literals;
+            } else { //Each clause should be unit clause by the formulation of PDDLs
+                throw new IllegalStateException("Each clause should be a unit clause.");
+            }
+        }
+        return literals;
+    }
+
+    //Finds the specific vertex reference for a state
+    private static PlanGraphState findStateVertex(int level, Literal literal, LabeledGraph<GraphPlanNode,MutexLink> graph) {
+        List<GraphPlanNode> vertices = graph.getVertexLabels();
+        for(GraphPlanNode vertex: vertices) {
+            if (vertex.getLevel() == level && vertex instanceof PlanGraphState && ((PlanGraphState) vertex).getLiteral().equals(literal)) {
+                return (PlanGraphState)vertex;
+            }
+        }
+        return null;
+    }
+}
+
+/**
+ * Enum to describe whether a link in the planning graph is mutex or non-mutex
+ */
+enum MutexLink { MUTEX, NONMUTEX }

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/GraphPlanNode.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/GraphPlanNode.java
@@ -1,0 +1,9 @@
+package aima.core.logic.fol.inference.graphplan;
+
+/**
+ * A node in a planning graph. Can either be an action node or a state node.
+ * @author Matt Grenander
+ */
+public interface GraphPlanNode {
+    int getLevel();
+}

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/GraphPlanSolutionExtractor.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/GraphPlanSolutionExtractor.java
@@ -1,0 +1,347 @@
+package aima.core.logic.fol.inference.graphplan;
+
+import aima.core.logic.fol.kb.data.Literal;
+import aima.core.util.datastructure.LabeledGraph;
+import aima.core.util.datastructure.Pair;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+/**
+ * A backwards search algorithm that attempts to find a solution in a given planning graph.
+ * @author Matt Grenander
+ */
+public class GraphPlanSolutionExtractor implements SolutionExtractor {
+    private static boolean triedBest;
+    private static int tries;
+
+    /**
+     * Attempts to extract a solution from a planning graph given a set of goals.
+     * @param graph
+     *              the planning graph
+     * @param goals
+     *              a list of literals that represents the goals
+     * @param numLevels
+     *              the maximum level in the planning graph
+     * @param nogoods
+     *              a HashSet that holds the previous failures from this method
+     * @return a list of actions if a solution is found, null otherwise
+     */
+    public List<PDDLAction> extractSolution(LabeledGraph<GraphPlanNode,MutexLink> graph, List<Literal> goals, int numLevels, HashSet<Pair<Integer,List<Literal>>> nogoods) {
+        //Check if we already marked this attempt as no good
+        for (Pair<Integer,List<Literal>> pair: nogoods) {
+            Set<Literal> noGoodLiterals = new HashSet<>(pair.getSecond());
+            Set<Literal> goalLiterals = new HashSet<>(goals);
+
+            if (pair.getFirst().equals(numLevels) && noGoodLiterals.equals(goalLiterals)) {
+                return null;
+            }
+        }
+
+        //Base case. Check if we are at the initial level, S_0
+        if (numLevels == 0) {
+            //Find initial states and see if the goals are contained
+            List<GraphPlanNode> vertices = graph.getVertexLabels();
+            List<Literal> initStates = new ArrayList<>();
+
+            for (GraphPlanNode vertex: vertices) {
+                if (vertex instanceof PlanGraphState && vertex.getLevel() == 0) {
+                    initStates.add(((PlanGraphState) vertex).getLiteral());
+                }
+            }
+
+            //See if the initial states contain the goals
+            if (initStates.containsAll(goals)) {
+                return new ArrayList<>(); //Return empty list to indicate success
+            } else { //Failure as we could not satisfy the goals
+                return null;
+            }
+        }
+
+        //Set indicator variables
+        triedBest = false;
+        tries = 0;
+
+        while(true) {
+            //Find best actions to take
+            List<PDDLAction> actionsToTake = findBestActions(graph, goals, numLevels);
+
+            //There are no valid actions to take
+            if (actionsToTake == null) {
+                break;
+            }
+
+            //We attempt to satisfy the preconditions of actionsToTake recursively
+            //Get preconditions of actions
+            List<Literal> newGoals = new ArrayList<>();
+            for (PDDLAction action: actionsToTake) {
+                newGoals.addAll(GraphPlan.CNFToLiteral(action.getPrecond()));
+            }
+
+            //Attempt recursion
+            List<PDDLAction> recurseActions = extractSolution(graph, newGoals, numLevels - 1, nogoods);
+
+            if (recurseActions != null) { //Recursion was successful - append actionsToTake and return
+                recurseActions.addAll(actionsToTake);
+                return recurseActions;
+            } else { //Try a different plan, if there is one
+                tries++;
+            }
+        }
+
+        //Mark this attempt as no good
+        nogoods.add(new Pair<>(numLevels,goals));
+        return null;
+    }
+
+    /**
+     * Finds the best action plan for the planning graph based on the heuristic given on pg. 385, given a set of goals and the current level.
+     * @param graph
+     *              the planning graph
+     * @param goals
+     *              the goal literals
+     * @param level
+     *              the current level we are searching at
+     * @return A valid list of actions to take to accomplish the goals, or null if there are none.
+     */
+    private static List<PDDLAction> findBestActions(LabeledGraph<GraphPlanNode,MutexLink> graph, List<Literal> goals, int level) {
+        if(!triedBest) { //Find the heuristic solution based on pg. 385
+            triedBest = true; //Ensures we don't try this again if it fails
+            PriorityQueue<Literal> sortedGoals = findSortedGoals(graph,goals);
+            List<PlanGraphAction> potentialActions = new ArrayList<>();
+
+            for (Literal goal: sortedGoals) {
+                //For each goal, pick the action that covers it with the lowest sum of precondition level costs
+                PlanGraphAction potentialAction = findBestActionForGoal(graph,goal,level);
+
+                if (potentialAction == null) { //We could not find any action for goal. So this problem is not solvable.
+                    return null;
+                } else if (!potentialActions.contains(potentialAction)) {
+                    potentialActions.add(potentialAction);
+                }
+            }
+
+            //If valid, we return the action plan
+            if (areValidActions(potentialActions,goals,graph)) {
+                List<PDDLAction> actions = new ArrayList<>();
+                for (PlanGraphAction actionState: potentialActions) {
+                    actions.add(actionState.getAction());
+                }
+                return actions;
+            }
+        }
+
+        //If findBestAction fails, we find any valid action plan
+        return findAnyActions(graph,goals,level);
+    }
+
+    /**
+     * Finds any valid action plan for the planning graph, given a set of goals and the current level.
+     * @param graph
+     *              the planning graph
+     * @param goals
+     *              the goal literals
+     * @param level
+     *              the current level we are searching at
+     * @return A valid list of actions to take to accomplish the goals, or null if there are none.
+     */
+    private static List<PDDLAction> findAnyActions(LabeledGraph<GraphPlanNode,MutexLink> graph, List<Literal> goals, int level) {
+        List<GraphPlanNode> vertices = graph.getVertexLabels();
+        List<PlanGraphAction> allActionsInLevel = new ArrayList<>();
+        for (GraphPlanNode vertex: vertices) {
+            if (vertex instanceof PlanGraphAction && vertex.getLevel() == level - 1) {
+                allActionsInLevel.add((PlanGraphAction)vertex);
+            }
+        }
+
+        //We iterate through all elements in the power set of the actions (i.e. every subset in A_i-1)
+        int stop = (int)Math.pow(2,allActionsInLevel.size());
+        while (tries < stop) {
+            //Get binary representation of tries, and pad with appropriate number of zeroes
+            String binary = Integer.toBinaryString(tries);
+            if(binary.length() != allActionsInLevel.size()) {
+                binary = String.format("%0$0" + allActionsInLevel.size() + "d", Integer.parseInt(binary));
+            }
+
+            List<PlanGraphAction> actionsToTry = new ArrayList<>();
+
+            //In the binary representation, if we find a 1, we take that action
+            //If we find a 0, we do not take the action. This gives us an ordering on the power set of the available actions.
+            for (int i = 0; i < binary.length(); i++) {
+                if (binary.charAt(i) == '1') {
+                    actionsToTry.add(allActionsInLevel.get(i));
+                }
+            }
+
+            //If actions are valid, we return them. Otherwise increment tries and attempt again.
+            if (areValidActions(actionsToTry,goals,graph)) {
+                List<PDDLAction> returnedActions = new ArrayList<>();
+                for (PlanGraphAction action: actionsToTry) {
+                    returnedActions.add(action.getAction());
+                }
+                return returnedActions;
+            } else {
+                tries++;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Sorts the goal literals by level cost and stores the results in a priority queue (pg. 382)
+     * @param graph
+     *              the planning graph
+     * @param goals
+     *              the goal literals
+     * @return a Priority Queue of the literal goals, sorted by level cost
+     */
+    private static PriorityQueue<Literal> findSortedGoals(LabeledGraph<GraphPlanNode,MutexLink> graph, List<Literal> goals) {
+        PriorityQueue<Literal> levelCost = new PriorityQueue<>((Literal l1, Literal l2)->findLevelCost(l2,graph)-findLevelCost(l1,graph));
+        List<GraphPlanNode> vertices = graph.getVertexLabels();
+
+        for (GraphPlanNode vertex: vertices) {
+            if (vertex instanceof PlanGraphState && goals.contains(((PlanGraphState) vertex).getLiteral())) {
+                Literal vLit = ((PlanGraphState) vertex).getLiteral();
+                if (!levelCost.contains(vLit)) {
+                    levelCost.add(vLit);
+                }
+            }
+        }
+        return levelCost;
+    }
+
+    /**
+     * Finds the level cost of a literal.
+     * @param literal
+     *                the goal literal
+     * @param graph
+     *                the planning graph
+     * @return The level cost of the literal.
+     */
+    private static int findLevelCost(Literal literal, LabeledGraph<GraphPlanNode,MutexLink> graph) {
+        List<GraphPlanNode> vertices = graph.getVertexLabels();
+        int levelCost = GraphPlan.numLevels(graph);
+
+        for (GraphPlanNode vertex: vertices) {
+            if (vertex instanceof PlanGraphState && ((PlanGraphState) vertex).getLiteral().equals(literal) && vertex.getLevel() < levelCost) {
+                levelCost = vertex.getLevel();
+            }
+        }
+        return levelCost;
+    }
+
+    /**
+     * Returns the best action (by smallest preconditions) for a given goal
+     * @param graph
+     *              the planning graph
+     * @param goal
+     *              the goal literal
+     * @param level
+     *              the level we are searching at
+     * @return The action with smallest preconditions
+     */
+    private static PlanGraphAction findBestActionForGoal(LabeledGraph<GraphPlanNode,MutexLink> graph, Literal goal, int level) {
+        List<GraphPlanNode> vertices = graph.getVertexLabels();
+        List<PlanGraphAction> potentialActions = new ArrayList<>();
+
+        //Find all valid actions
+        for (GraphPlanNode vertex: vertices) {
+            if (vertex instanceof PlanGraphAction && vertex.getLevel() == level - 1) {
+                PlanGraphAction action = ((PlanGraphAction)vertex);
+                if (GraphPlan.CNFToLiteral(action.getAction().getEffect()).contains(goal)) {
+                    potentialActions.add(action);
+                }
+            }
+        }
+
+        //No actions satisfy the goal, return null
+        if (potentialActions.isEmpty()) {
+            return null;
+        }
+
+        //Find the action with the smallest preconditions, by level cost
+        PlanGraphAction bestAction = potentialActions.get(0);
+        int bestActionSum = sumPreconditions(bestAction, graph);
+
+        for (PlanGraphAction potentialAction: potentialActions) {
+            int potActionSum = sumPreconditions(potentialAction,graph);
+
+            if (potActionSum < bestActionSum) { //We found a better action
+                bestAction = potentialAction;
+                bestActionSum = potActionSum;
+            }
+        }
+
+        return bestAction;
+    }
+
+    /**
+     * Sums the level costs of the preconditions of an action.
+     * @param a
+     *          the action
+     * @param graph
+     *          the planning graph, needed to compute the level cost
+     * @return The sum described above.
+     */
+    private static int sumPreconditions(PlanGraphAction a, LabeledGraph<GraphPlanNode,MutexLink> graph) {
+        int sum = 0;
+        for (Literal l: GraphPlan.CNFToLiteral(a.getAction().getPrecond())) {
+            sum += findLevelCost(l,graph);
+        }
+        return sum;
+    }
+
+    /**
+     * Determines if the effects of the actions supplied cover the given goals and are non-mutex.
+     * @param actions
+     *                the actions we are examining
+     * @param goals
+     *                the goal literals
+     * @param graph
+     *                the planning graph
+     * @return True if the actions cover the goals and are non-mutex. False otherwise.
+     */
+    private static boolean areValidActions(List<PlanGraphAction> actions, List<Literal> goals, LabeledGraph<GraphPlanNode,MutexLink> graph) {
+        //Check if actions are all non-mutex
+        if (!actionsNonMutex(actions,graph)) {
+            return false;
+        }
+
+        List<Literal> allEffects = new ArrayList<>();
+        for (PlanGraphAction action: actions) {
+            allEffects.addAll(GraphPlan.CNFToLiteral(action.getAction().getEffect()));
+        }
+
+        return allEffects.containsAll(goals);
+    }
+
+    /**
+     * Determines if every pair of actions are non-mutex. Used in the heuristic solution for findBestAction.
+     * @param actions
+     *                PDDLActions to be checked.
+     * @param graph
+     *                the planning graph they are in
+     * @return true if all actions are non-mutex. False otherwise.
+     */
+    private static boolean actionsNonMutex(List<PlanGraphAction> actions, LabeledGraph<GraphPlanNode,MutexLink> graph) {
+        if (actions.size() <= 1) { //Not possible for pairs to be mutex if there's only one.
+            return true;
+        }
+
+        //Iterate through each pair
+        for(PlanGraphAction a1: actions) {
+            for (PlanGraphAction a2: actions) {
+                if (!a1.equals(a2)) {
+                    MutexLink edge = graph.get(a1,a2);
+                    if (edge != null && edge == MutexLink.MUTEX) {
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/PDDL.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/PDDL.java
@@ -1,0 +1,33 @@
+package aima.core.logic.fol.inference.graphplan;
+
+import aima.core.logic.fol.kb.data.CNF;
+
+import java.util.List;
+
+/**
+ * Describes a PDDL problem in classical planning
+ * @author Matt Grenander
+ */
+public class PDDL {
+    private List<PDDLAction> actionSchema;
+    private CNF init;
+    private CNF goal;
+
+    public PDDL(List<PDDLAction> actions, CNF init, CNF goal) {
+        this.actionSchema = actions;
+        this.init = init;
+        this.goal = goal;
+    }
+
+    public CNF getInit() {
+        return init;
+    }
+
+    public CNF getGoal() {
+        return goal;
+    }
+
+    public List<PDDLAction> getActions() {
+        return actionSchema;
+    }
+}

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/PDDLAction.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/PDDLAction.java
@@ -1,0 +1,43 @@
+package aima.core.logic.fol.inference.graphplan;
+
+import aima.core.agent.Action;
+import aima.core.logic.fol.kb.data.CNF;
+
+/**
+ * Class that represents an action in a PDDL problem.
+ * @author Matt Grenander
+ */
+public class PDDLAction implements Action {
+    private String name;
+    private CNF precond;
+    private CNF effect;
+
+    public PDDLAction(String name, CNF precond, CNF effect) {
+        this.name = name;
+        this.precond = precond;
+        this.effect = effect;
+    }
+
+    //If the action is equal to the preconditions then this action is a NoOp
+    public boolean isNoOp() {
+        return precond.equals(effect);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String toString() { return name; }
+
+    public CNF getPrecond() {
+        return precond;
+    }
+
+    public CNF getEffect() {
+        return effect;
+    }
+
+    public boolean equals(PDDLAction o) {
+        return this.name.equals(o.name) && this.precond.equals(o.precond) && this.effect.equals(o.effect);
+    }
+}

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/PlanGraphAction.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/PlanGraphAction.java
@@ -1,0 +1,32 @@
+package aima.core.logic.fol.inference.graphplan;
+
+/**
+ * Node for planning graph that represents an action.
+ * @author Matt Grenander
+ */
+public class PlanGraphAction implements GraphPlanNode {
+    private int level;
+    private PDDLAction action;
+
+    PlanGraphAction(int level, PDDLAction action) {
+        this.level = level;
+        this.action = action;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public PDDLAction getAction() {
+        return action;
+    }
+
+    public boolean equals(PlanGraphAction o) {
+        return this.level == o.level && this.action == o.action;
+    }
+
+    @Override
+    public String toString() {
+        return "Level=" + level + ", Action=" + action.getName() + ". ";
+    }
+}

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/PlanGraphState.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/PlanGraphState.java
@@ -1,0 +1,38 @@
+package aima.core.logic.fol.inference.graphplan;
+
+import aima.core.logic.fol.kb.data.Literal;
+
+/**
+ * Node for planning graph that represents a state
+ * @author Matt Grenander
+ */
+public class PlanGraphState implements GraphPlanNode {
+    private int level;
+    private Literal literal;
+
+    PlanGraphState(int level, Literal literal) {
+        this.level = level;
+        this.literal = literal;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public Literal getLiteral() {
+        return literal;
+    }
+
+    public boolean equals(PlanGraphState o) {
+        if (o == null) {
+            return false;
+        }
+
+        return (this.level == o.level && this.literal.equals(o.literal));
+    }
+
+    @Override
+    public String toString() {
+        return "Level=" + level + ", Literal=" + literal + ". ";
+    }
+}

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/SolutionExtractor.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/graphplan/SolutionExtractor.java
@@ -1,0 +1,16 @@
+package aima.core.logic.fol.inference.graphplan;
+
+import aima.core.logic.fol.kb.data.Literal;
+import aima.core.util.datastructure.LabeledGraph;
+import aima.core.util.datastructure.Pair;
+
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Interface to be implemented to extract solution from a planning graph
+ * @author Matt Grenander
+ */
+public interface SolutionExtractor {
+    List<PDDLAction> extractSolution(LabeledGraph<GraphPlanNode, MutexLink> graph, List<Literal> goals, int numLevels, HashSet<Pair<Integer, List<Literal>>> nogoods);
+}

--- a/aima-core/src/main/java/aima/core/logic/fol/kb/data/CNF.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/kb/data/CNF.java
@@ -1,8 +1,6 @@
 package aima.core.logic.fol.kb.data;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 /**
  * Conjunctive Normal Form (CNF) : a conjunction of clauses, where each clause
@@ -38,5 +36,27 @@ public class CNF {
 		}
 
 		return sb.toString();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj == null) {
+			return false;
+		}
+
+		if (this == obj) {
+			return true;
+		}
+
+		if (!(obj instanceof CNF)) {
+			return false;
+		}
+
+		CNF othCnf = (CNF)obj;
+
+		//Convert the lists to sets as we don't care about order
+		Set<Clause> thisSet = new HashSet<>(this.conjunctionOfClauses);
+		Set<Clause> othSet = new HashSet<>(othCnf.conjunctionOfClauses);
+		return thisSet.equals(othSet);
 	}
 }

--- a/aima-core/src/main/java/aima/core/logic/fol/kb/data/Literal.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/kb/data/Literal.java
@@ -1,6 +1,7 @@
 package aima.core.logic.fol.kb.data;
 
 import aima.core.logic.fol.parsing.ast.AtomicSentence;
+import aima.core.logic.fol.parsing.ast.Predicate;
 import aima.core.logic.fol.parsing.ast.Term;
 
 /**
@@ -31,6 +32,8 @@ public class Literal {
 		return new Literal(atom, negativeLiteral);
 	}
 
+	public Literal newNegInstance(AtomicSentence atom) { return new Literal(atom, !negativeLiteral); }
+
 	public boolean isPositiveLiteral() {
 		return !negativeLiteral;
 	}
@@ -42,6 +45,9 @@ public class Literal {
 	public AtomicSentence getAtomicSentence() {
 		return atom;
 	}
+
+	//Returns true if other is the negative of this literal, false otherwise
+	public boolean isNegativeOf(Literal oth) { return oth != null && oth.equals(this.newNegInstance(this.atom)); }
 
 	@Override
 	public String toString() {

--- a/aima-core/src/test/java/aima/test/core/unit/logic/fol/inference/GraphPlanTest.java
+++ b/aima-core/src/test/java/aima/test/core/unit/logic/fol/inference/GraphPlanTest.java
@@ -1,0 +1,86 @@
+package aima.test.core.unit.logic.fol.inference;
+
+import aima.core.logic.fol.domain.DomainFactory;
+import aima.core.logic.fol.domain.FOLDomain;
+import aima.core.logic.fol.inference.graphplan.GraphPlan;
+import aima.core.logic.fol.inference.graphplan.GraphPlanSolutionExtractor;
+import aima.core.logic.fol.inference.graphplan.PDDL;
+import aima.core.logic.fol.inference.graphplan.PDDLAction;
+import aima.core.logic.fol.kb.data.CNF;
+import aima.core.logic.fol.kb.data.Clause;
+import aima.core.logic.fol.kb.data.Literal;
+import aima.core.logic.fol.parsing.FOLParser;
+import aima.core.logic.fol.parsing.ast.Predicate;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for GraphPlan, figure 10.9 in AIMA3e.
+ * @author Matt Grenander
+ */
+public class GraphPlanTest {
+    /**
+     * Spare tire example from page 370 and 383 - 385 in AIMA3e.
+     */
+    @Test
+    public void spareTireTest() {
+        FOLDomain domain = new FOLDomain(DomainFactory.spareTireDomain());
+        FOLParser parser = new FOLParser(domain);
+
+        //At clauses
+        ArrayList<Clause> at = new ArrayList<>(12);
+        String[] tires = {"Spare","Flat"};
+        String[] locations = {"Trunk","Ground","Axle"};
+
+        //Positive literals
+        for (String tire: tires) {
+            for (String location: locations) {
+                parser.setUpToParse("At(" + tire + "," + location + ")");
+                at.add(new Clause(Collections.singletonList(new Literal((Predicate)parser.parsePredicate(), false))));
+            }
+        }
+
+        //Negative literals
+        for (String tire: tires) {
+            for (String location: locations) {
+                parser.setUpToParse("At(" + tire + "," + location + ")");
+                at.add(new Clause(Collections.singletonList(new Literal((Predicate)parser.parsePredicate(), true))));
+            }
+        }
+
+        //Create the PDDL
+        //Initial states are literals 5,0,8,10,7,9
+        CNF init = new CNF(Arrays.asList(at.get(5),at.get(0),at.get(8),at.get(10),at.get(7),at.get(9)));
+
+        //Goal state is literal 2
+        CNF goal = new CNF(Collections.singletonList(at.get(2)));
+
+        //Actions
+        PDDLAction leave = new PDDLAction("LeaveOvernight", new CNF(Collections.singletonList(new Clause())), new CNF(Arrays.asList(at.get(6),at.get(7),at.get(8),at.get(9),at.get(10),at.get(11))));
+        PDDLAction rm1 = new PDDLAction("Remove(Spare,Axle)", new CNF(Collections.singletonList(at.get(2))), new CNF(Arrays.asList(at.get(8),at.get(1))));
+        PDDLAction rm2 = new PDDLAction("Remove(Spare,Trunk)", new CNF(Collections.singletonList(at.get(0))), new CNF(Arrays.asList(at.get(6),at.get(1))));
+        PDDLAction rm3 = new PDDLAction("Remove(Flat,Axle)", new CNF(Collections.singletonList(at.get(5))), new CNF(Arrays.asList(at.get(11),at.get(4))));
+        PDDLAction rm4 = new PDDLAction("Remove(Flat,Trunk)", new CNF(Collections.singletonList(at.get(3))), new CNF(Arrays.asList(at.get(9),at.get(10))));
+        PDDLAction put1 = new PDDLAction("PutOn(Spare,Axle)", new CNF(Arrays.asList(at.get(1),at.get(11))), new CNF(Arrays.asList(at.get(7),at.get(2))));
+        PDDLAction put2 = new PDDLAction("PutOn(Flat,Axle)", new CNF(Arrays.asList(at.get(4),at.get(11))), new CNF(Arrays.asList(at.get(10),at.get(5))));
+
+        PDDL pddl = new PDDL(Arrays.asList(leave,rm1,rm2,rm3,rm4,put1,put2),init,goal);
+
+        //Find solution
+        GraphPlanSolutionExtractor solEx = new GraphPlanSolutionExtractor();
+        GraphPlan graphPlanner = new GraphPlan(solEx);
+        List<PDDLAction> graphPlanSolution = graphPlanner.graphPlan(pddl);
+
+        //Expected Solution: [Remove(Spare,Trunk), Remove(Flat,Axle), PutOn(Spare,Axle)]
+        List<PDDLAction> expectedSolution = Arrays.asList(rm2,rm3,put1);
+
+        assertEquals(expectedSolution,graphPlanSolution);
+    }
+}


### PR DESCRIPTION
Issue [#34](https://github.com/aimacode/aima-java/issues/34): Added implementation of the GraphPlan algorithm. I modeled most of my documentation syntax off of the SATPlan implementation. There is also a test case from the textbook, the spare tire example described on page 370 and 383 - 385 in AIMA3e.

If there's any feedback please let me know.