### PR TITLE
Update ProbabilityNumber interface and implementations

### DIFF
--- a/extra/src/main/java/aima/extra/probability/BigDecimalProbabilityNumber.java
+++ b/extra/src/main/java/aima/extra/probability/BigDecimalProbabilityNumber.java
@@ -7,43 +7,46 @@ import java.math.RoundingMode;
 
 /**
  * Implementation based on the underlying BigDecimal datatype. Supports higher
- * precision than DoubleProbabilityNumber (DECIMAL128 precision by default, but
- * can go upto UNLIMITED). The class is immutable.
+ * precision than DoubleProbabilityNumber (precision of result is determined by
+ * operands, but can be specified to any arbitrary precision upto UNLIMITED
+ * precision). The class is immutable.
  * 
  * @author Nagaraj Poti
  *
  */
-public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparable<ProbabilityNumber> {
+public class BigDecimalProbabilityNumber implements ProbabilityNumber {
 
-	// Constants
-
-	/**
-	 * IEEE 754R Decimal128 format - Precision of 34 digits and a rounding mode
-	 * of HALF_EVEN. HALF_EVEN rounding mode statistically minimizes cumulative
-	 * error when applied repeatedly over a sequence of calculations.
-	 */
-	private static final Integer DEFAULT_PRECISION = MathContext.DECIMAL128.getPrecision();
-
-	private static final RoundingMode DEFAULT_PRECISION_ROUNDING_MODE = MathContext.DECIMAL128.getRoundingMode();
+	// Static members
 
 	/**
 	 * Maximum integer value that can be accomodated as exponent in the
-	 * BigDecimal pow() function
+	 * BigDecimal pow() function.
 	 */
 	private static final int EXPONENT_MAX = 999999999;
+
+	/**
+	 * Global precision setting for operations. Set to null by default but can
+	 * be overriden to ensure all computation results are specified to this
+	 * precision.
+	 */
+	private static MathContext ARBITRARY_PRECISION = null;
+
+	/**
+	 * Constants of UNLIMITED precision.
+	 */
+	private static BigDecimal BIG_DECIMAL_ZERO = new BigDecimal(0);
+
+	private static BigDecimal BIG_DECIMAL_ONE = new BigDecimal(1);
 
 	// Internal fields
 
 	private BigDecimal value;
 
 	/**
-	 * MathContext of value.
+	 * HALF_EVEN rounding mode statistically minimizes cumulative error when
+	 * applied repeatedly over a sequence of calculations. Set as default
 	 */
-	private MathContext precisionMathContext = new MathContext(DEFAULT_PRECISION, DEFAULT_PRECISION_ROUNDING_MODE);
-
-	private BigDecimal BIG_DECIMAL_ZERO = new BigDecimal(0, precisionMathContext);
-
-	private BigDecimal BIG_DECIMAL_ONE = new BigDecimal(1, precisionMathContext);
+	private RoundingMode roundingMode = RoundingMode.HALF_EVEN;
 
 	// Constructors
 
@@ -57,22 +60,9 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 	 */
 	public BigDecimalProbabilityNumber(double value) {
 		if (value < 0 || value > 1) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("Probability value must be between 0 and 1");
 		}
-		this.value = new BigDecimal(Double.toString(value), precisionMathContext);
-	}
-
-	/**
-	 * Construct a BigDecimalProbabilityNumber from BigDecimal type.
-	 * 
-	 * @param value
-	 *            to be assigned.
-	 */
-	public BigDecimalProbabilityNumber(BigDecimal value) {
-		if (null == value || value.compareTo(BIG_DECIMAL_ZERO) == -1 || value.compareTo(BIG_DECIMAL_ONE) == 1) {
-			throw new IllegalArgumentException();
-		}
-		this.value = new BigDecimal(value.toString(), precisionMathContext);
+		this.value = BigDecimal.valueOf(value);
 	}
 
 	/**
@@ -85,73 +75,24 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 	 *            MathContext to be associated with value.
 	 */
 	public BigDecimalProbabilityNumber(BigDecimal value, MathContext mc) {
-		precisionMathContext = mc;
-		setConstants();
 		if (value.compareTo(BIG_DECIMAL_ZERO) == -1 || value.compareTo(BIG_DECIMAL_ONE) == 1) {
-			throw new IllegalArgumentException();
-		}
-		this.value = new BigDecimal(value.toString(), precisionMathContext);
-	}
-
-	// Private methods
-
-	/**
-	 * Initialize constants BIG_DECIMAL_ZERO and BIG_DECIMAL_ONE according to
-	 * precisionMathContext that is defined.
-	 */
-	private void setConstants() {
-		BIG_DECIMAL_ZERO = new BigDecimal(0, precisionMathContext);
-		BIG_DECIMAL_ONE = new BigDecimal(1, precisionMathContext);
-	}
-
-	/**
-	 * Covert other implementations of the ProbabilityNumber interface to a
-	 * BigDecimalProbabilityNumber.
-	 * 
-	 * @param that
-	 *            BigDecimalProbabilityNumber.
-	 */
-	private BigDecimalProbabilityNumber toInternalType(ProbabilityNumber that) {
-		if (that instanceof BigDecimalProbabilityNumber) {
-			return (BigDecimalProbabilityNumber) that;
-		}
-		return new BigDecimalProbabilityNumber(that.getValue(), that.getMathContext());
-	}
-
-	/**
-	 * Compare two BigDecimal values upto minimum precision.
-	 * 
-	 * @param first
-	 *            of BigDecimal type.
-	 * @param second
-	 *            of BigDecimal type.
-	 * 
-	 * @return 1 if first > second, 0 if first == second, -1 if first < second.
-	 */
-	private int compareBigDecimal(BigDecimal first, MathContext mc1, BigDecimal second, MathContext mc2) {
-		if (mc1.getPrecision() == mc2.getPrecision()) {
-			return first.compareTo(second);
-		}
-		int minPrecision = getMinPrecision(mc1.getPrecision(), mc2.getPrecision());
-		BigDecimal valueA = new BigDecimal(first.toString(), new MathContext(minPrecision, mc1.getRoundingMode()));
-		BigDecimal valueB = new BigDecimal(second.toString(), new MathContext(minPrecision, mc2.getRoundingMode()));
-		return valueA.compareTo(valueB);
-	}
-
-	/**
-	 * Return the minimum of two precision values. If any of the precision
-	 * values is 0, the maximum value of the two is returned.
-	 * 
-	 * @param precisionA
-	 * @param precisionB
-	 * @return
-	 */
-	private int getMinPrecision(int precisionA, int precisionB) {
-		if (precisionA == 0 || precisionB == 0) {
-			return Math.max(precisionA, precisionB);
+			throw new IllegalArgumentException("Probability value must be between 0 and 1");
+		} else if (null == mc) {
+			this.value = value;
 		} else {
-			return Math.min(precisionA, precisionB);
+			this.value = new BigDecimal(value.toString(), mc);
+			this.roundingMode = mc.getRoundingMode();
 		}
+	}
+
+	/**
+	 * Construct a BigDecimalProbabilityNumber from BigDecimal type.
+	 * 
+	 * @param value
+	 *            to be assigned.
+	 */
+	public BigDecimalProbabilityNumber(BigDecimal value) {
+		this(value, null);
 	}
 
 	// Public methods
@@ -161,74 +102,49 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 	 */
 	@Override
 	public BigDecimal getValue() {
-		return value;
+		return this.value;
 	}
 
 	/**
-	 * @return precisionMathContext used by value set to DECIMAL128 precision
-	 *         and HALF_EVEN RoundingMode by default.
+	 * @return MathContext associated with the value.
 	 */
 	@Override
 	public MathContext getMathContext() {
-		return precisionMathContext;
+		return new MathContext(this.value.precision(), this.roundingMode);
 	}
 
 	/**
-	 * Checks if the value is zero or not. The first check is an absolute check
-	 * upto MAX_PRECISION digits. If the check fails, an approximation check
-	 * based on the specified DEFAULT_SCALE and DEFAULT_SCALE_ROUNDING_MODE is
-	 * made.
+	 * Checks if the value is zero or not.
 	 * 
 	 * @return true if zero, false otherwise.
 	 */
 	@Override
 	public boolean isZero() {
-		return (compareBigDecimal(this.value, this.precisionMathContext, BIG_DECIMAL_ZERO, this.precisionMathContext) == 0);
+		return (compareBigDecimal(this.value, this.getMathContext(), BIG_DECIMAL_ZERO, MathContext.UNLIMITED) == 0);
 	}
 
 	/**
-	 * Checks if the value is one. The first check is an absolute check upto
-	 * MAX_PRECISION digits. If the check fails, an approximation check based on
-	 * the specified DEFAULT_SCALE and DEFAULT_SCALE_ROUNDING_MODE is made.
+	 * Checks if the value is one.
 	 * 
 	 * @return true if one, false otherwise.
 	 */
 	@Override
 	public boolean isOne() {
-		return (compareBigDecimal(this.value, this.precisionMathContext, BIG_DECIMAL_ONE, this.precisionMathContext) == 0);
+		return (compareBigDecimal(this.value, this.getMathContext(), BIG_DECIMAL_ONE, MathContext.UNLIMITED) == 0);
 	}
 
 	/**
-	 * Checks if argument implementing ProbabilityNumber interface is equal to
-	 * the value of the current BigDecimalProbabilityNumber. The check between
-	 * two ProbabilityNumbers involves a check only upto the minimum precision
-	 * of the two values, i.e min(this.precision(), that.precision()).
+	 * Checks if the probability value represented is valid i.e it falls within
+	 * the range [0, 1]. It is possible for operations on ProbabilityNumber
+	 * instances to cause the result to either overflow or underflow the range
+	 * [0, 1].
 	 * 
-	 * @param that
-	 *            the ProbabilityNumber type that is to be compared with this
-	 *            BigDecimalProbabilityNumber.
-	 *
-	 * @return true if this == that upto precision value specified by
-	 *         min(this.precision(), that.precision()), false otherwise.
+	 * @return true if a valid probability value, false otherwise.
 	 */
 	@Override
-	public boolean equals(ProbabilityNumber that) {
-		BigDecimalProbabilityNumber specificType = toInternalType(that);
-		return (compareBigDecimal(this.value, this.precisionMathContext, specificType.getValue(), specificType.getMathContext()) == 0);
-	}
-	
-	/**
-	 * Compare this with another ProbabilityNumber value (that).
-	 * 
-	 * @param that
-	 *            of type ProbabilityNumber.
-	 * 
-	 * @return 1 if this > that, 0 if this == that, -1 if this < that.
-	 */
-	@Override
-	public int compareTo(ProbabilityNumber that) {
-		BigDecimalProbabilityNumber second = toInternalType(that);
-		return compareBigDecimal(this.value, this.precisionMathContext, second.getValue(), second.getMathContext());
+	public boolean isValid() {
+		return (this.compareTo(new BigDecimalProbabilityNumber(BIG_DECIMAL_ZERO, MathContext.UNLIMITED)) >= 0
+				&& this.compareTo(new BigDecimalProbabilityNumber(BIG_DECIMAL_ONE, MathContext.UNLIMITED)) <= 0);
 	}
 
 	/**
@@ -244,9 +160,8 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 	@Override
 	public ProbabilityNumber add(ProbabilityNumber that) {
 		BigDecimalProbabilityNumber addend = toInternalType(that);
-		int minPrecision = getMinPrecision(this.precisionMathContext.getPrecision(), addend.getMathContext().getPrecision());
-		MathContext resultMathContext = new MathContext(minPrecision, DEFAULT_PRECISION_ROUNDING_MODE);
-		return new BigDecimalProbabilityNumber(value.add(addend.getValue(), resultMathContext), resultMathContext);
+		MathContext resultMathContext = getResultMathContext(this.getMathContext(), addend.getMathContext());
+		return new BigDecimalProbabilityNumber(this.value.add(addend.value, resultMathContext));
 	}
 
 	/**
@@ -263,11 +178,8 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 	@Override
 	public ProbabilityNumber subtract(ProbabilityNumber that) {
 		BigDecimalProbabilityNumber subtrahend = toInternalType(that);
-		int minPrecision = getMinPrecision(this.precisionMathContext.getPrecision(),
-				subtrahend.getMathContext().getPrecision());
-		MathContext resultMathContext = new MathContext(minPrecision, DEFAULT_PRECISION_ROUNDING_MODE);
-		return new BigDecimalProbabilityNumber(value.subtract(subtrahend.getValue(), resultMathContext),
-				resultMathContext);
+		MathContext resultMathContext = getResultMathContext(this.getMathContext(), subtrahend.getMathContext());
+		return new BigDecimalProbabilityNumber(this.value.subtract(subtrahend.value, resultMathContext));
 	}
 
 	/**
@@ -284,10 +196,8 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 	@Override
 	public ProbabilityNumber multiply(ProbabilityNumber that) {
 		BigDecimalProbabilityNumber multiplier = toInternalType(that);
-		int minPrecision = getMinPrecision(this.precisionMathContext.getPrecision(),
-				multiplier.getMathContext().getPrecision());
-		MathContext resultMathContext = new MathContext(minPrecision, DEFAULT_PRECISION_ROUNDING_MODE);
-		return new BigDecimalProbabilityNumber(value.multiply(multiplier.value, resultMathContext), resultMathContext);
+		MathContext resultMathContext = getResultMathContext(this.getMathContext(), multiplier.getMathContext());
+		return new BigDecimalProbabilityNumber(this.value.multiply(multiplier.value, resultMathContext));
 	}
 
 	/**
@@ -304,11 +214,10 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 	public ProbabilityNumber divide(ProbabilityNumber that) {
 		BigDecimalProbabilityNumber divisor = toInternalType(that);
 		if (divisor.isZero()) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("Division by 0 not allowed");
 		}
-		int minPrecision = getMinPrecision(this.precisionMathContext.getPrecision(), divisor.getMathContext().getPrecision());
-		MathContext resultMathContext = new MathContext(minPrecision, DEFAULT_PRECISION_ROUNDING_MODE);
-		return new BigDecimalProbabilityNumber(value.divide(divisor.value, resultMathContext), resultMathContext);
+		MathContext resultMathContext = getResultMathContext(this.getMathContext(), divisor.getMathContext());
+		return new BigDecimalProbabilityNumber(this.value.divide(divisor.value, resultMathContext));
 	}
 
 	/**
@@ -322,7 +231,11 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 	 */
 	@Override
 	public ProbabilityNumber pow(int exponent) {
-		return new BigDecimalProbabilityNumber(value.pow(exponent, precisionMathContext));
+		if (exponent > EXPONENT_MAX) {
+			return pow(BigInteger.valueOf(exponent));
+		}
+		MathContext resultMathContext = getResultMathContext(this.getMathContext(), MathContext.UNLIMITED);
+		return new BigDecimalProbabilityNumber(this.value.pow(exponent, resultMathContext));
 	}
 
 	/**
@@ -341,13 +254,14 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 			int exp = exponent.intValueExact();
 			return pow(exp);
 		} else {
+			MathContext resultMathContext = getResultMathContext(this.getMathContext(), MathContext.UNLIMITED);
 			BigDecimal result = BIG_DECIMAL_ONE;
 			BigDecimal base = value;
 			while (exponent.compareTo(BigInteger.valueOf(0)) == 1) {
 				if (exponent.mod(BigInteger.valueOf(2)).compareTo(BigInteger.valueOf(1)) == 0) {
-					result = result.multiply(base, precisionMathContext);
+					result = result.multiply(base, resultMathContext);
 				}
-				base = base.multiply(base, precisionMathContext);
+				base = base.multiply(base, resultMathContext);
 				exponent = exponent.divide(BigInteger.valueOf(2));
 			}
 			return new BigDecimalProbabilityNumber(result);
@@ -374,8 +288,143 @@ public class BigDecimalProbabilityNumber implements ProbabilityNumber, Comparabl
 		}
 		return this.isOne();
 	}
-	
+
+	/**
+	 * Override the precision of ProbabilityNumber instances returned as a
+	 * result of performing operations.
+	 * 
+	 * @param mc
+	 */
+	@Override
+	public void overrideComputationPrecisionGlobally(MathContext mc) {
+		ARBITRARY_PRECISION = mc;
+	}
+
+	/**
+	 * Checks if argument implementing ProbabilityNumber interface is equal to
+	 * the value of the current BigDecimalProbabilityNumber. The check between
+	 * two ProbabilityNumbers involves a check only upto the minimum precision
+	 * of the two values, i.e min(this.precision(), that.precision()).
+	 * 
+	 * @param that
+	 *            the ProbabilityNumber type that is to be compared with this
+	 *            BigDecimalProbabilityNumber.
+	 *
+	 * @return true if this == that upto precision value specified by
+	 *         min(this.precision(), that.precision()), false otherwise.
+	 */
+	@Override
+	public boolean equals(Object that) {
+		BigDecimalProbabilityNumber specificType = toInternalType((ProbabilityNumber) that);
+		return (this.compareTo(specificType) == 0);
+	}
+
+	/**
+	 * Compare this with another ProbabilityNumber value (that).
+	 * 
+	 * @param that
+	 *            of type ProbabilityNumber.
+	 * 
+	 * @return 1 if this > that, 0 if this == that, -1 if this < that.
+	 */
+	@Override
+	public int compareTo(ProbabilityNumber that) {
+		BigDecimalProbabilityNumber second = toInternalType(that);
+		return compareBigDecimal(this.value, this.getMathContext(), second.value, second.getMathContext());
+	}
+
+	/**
+	 * @return string representation of value.
+	 */
 	public String toString() {
 		return getValue().toString();
+	}
+
+	// Private methods
+
+	/**
+	 * Covert other implementations of the ProbabilityNumber interface to a
+	 * BigDecimalProbabilityNumber.
+	 * 
+	 * @param that
+	 *            BigDecimalProbabilityNumber.
+	 */
+	private BigDecimalProbabilityNumber toInternalType(ProbabilityNumber that) {
+		if (that instanceof BigDecimalProbabilityNumber) {
+			return (BigDecimalProbabilityNumber) that;
+		}
+		return new BigDecimalProbabilityNumber(that.getValue());
+	}
+
+	/**
+	 * Compare two BigDecimal values upto minimum precision.
+	 * 
+	 * @param first
+	 *            of BigDecimal type.
+	 * @param second
+	 *            of BigDecimal type.
+	 * 
+	 * @return 1 if first > second, 0 if first == second, -1 if first < second.
+	 */
+	private int compareBigDecimal(BigDecimal first, MathContext mc1, BigDecimal second, MathContext mc2) {
+		if (mc1.getPrecision() == mc2.getPrecision()) {
+			return first.compareTo(second);
+		}
+		int minPrecision = getMinPrecision(mc1.getPrecision(), mc2.getPrecision());
+		if (mc1.getPrecision() == minPrecision) {
+			BigDecimal valueB = new BigDecimal(second.toString(), new MathContext(minPrecision, mc2.getRoundingMode()));
+			return first.compareTo(valueB);
+		} else {
+			BigDecimal valueA = new BigDecimal(first.toString(), new MathContext(minPrecision, mc1.getRoundingMode()));
+			return valueA.compareTo(second);
+		}
+	}
+
+	/**
+	 * Compare two MathContext objects corresponding to operands and create the
+	 * MathContext object associated with the result. If ARBITRARY_PRECISION is
+	 * overriden, it takes precedence and is returned back. Otherwise return
+	 * MathContext set to minimum of two precision values plus one. If both
+	 * values are 0, then 0 is returned. If either one of the precision values
+	 * is 0, then the other value plus one is returned.
+	 * 
+	 * @param mcA
+	 *            MathContext object of this instance.
+	 * @param mcB
+	 * 
+	 * @return resultMathContext with precision set to (min(precisionA,
+	 *         precisionB) + 1) or 0 (if both precision values are 0) or
+	 *         ARBITRARY_PRECISION if not null. The RoundingMode is set to that
+	 *         of mcA.
+	 */
+	private MathContext getResultMathContext(MathContext mcA, MathContext mcB) {
+		if (null == ARBITRARY_PRECISION) {
+			int minPrecision = getMinPrecision(mcA.getPrecision(), mcB.getPrecision());
+			if (minPrecision == 0) {
+				return new MathContext(minPrecision, mcA.getRoundingMode());
+			} else {
+				return new MathContext(minPrecision + 1, mcA.getRoundingMode());
+			}
+		} else {
+			return ARBITRARY_PRECISION;
+		}
+	}
+
+	/**
+	 * Return the minimum of two precision values. If either of the precision
+	 * values is 0, then the other value is returned.
+	 * 
+	 * @param precisionA
+	 * @param precisionB
+	 * 
+	 * @return min(precisionA, precisionB) if both precisionA and precisionB are
+	 *         non-zero, otherwise max(precisionA, precisionB).
+	 */
+	private int getMinPrecision(int precisionA, int precisionB) {
+		if (precisionA == 0 || precisionB == 0) {
+			return Math.max(precisionA, precisionB);
+		} else {
+			return Math.min(precisionA, precisionB);
+		}
 	}
 }

--- a/extra/src/main/java/aima/extra/probability/DoubleProbabilityNumber.java
+++ b/extra/src/main/java/aima/extra/probability/DoubleProbabilityNumber.java
@@ -8,16 +8,16 @@ import java.math.RoundingMode;
 /**
  * A simple wrapper class for operations with the primitive Java double
  * datatype. The maximum precision achievable is that supported by double
- * datatype. The double primitive type conforms to the IEEE 754 standard's 64
- * bit double precision format (1 sign bit, 11 bits for the exponent and 52 bits
- * for the significand). The class is immutable.
+ * datatype (approximately 15.95 digits). The double primitive type conforms to
+ * the IEEE 754 standard's 64 bit double precision format (1 sign bit, 11 bits
+ * for the exponent and 52 bits for the significand). The class is immutable.
  * 
  * @author Nagaraj Poti
  * 
  */
-public class DoubleProbabilityNumber implements ProbabilityNumber, Comparable<ProbabilityNumber> {
+public class DoubleProbabilityNumber implements ProbabilityNumber {
 
-	// Constants
+	// Static members
 
 	/**
 	 * Default threshold for checking rounding errors.
@@ -29,23 +29,17 @@ public class DoubleProbabilityNumber implements ProbabilityNumber, Comparable<Pr
 	 * According to the IEEE 754 format, double values have a precision of 15.95
 	 * decimal digits. Here, max_precision is set to 15 digits by default.
 	 */
-	private static final Integer DEFAULT_MAX_PRECISION = MathContext.DECIMAL64.getPrecision() - 1;
+	private static Integer MAX_PRECISION = MathContext.DECIMAL64.getPrecision() - 1;
 
 	/**
 	 * RoundingMode.HALF_EVEN statistically minimizes cumulative error when
 	 * applied repeatedly over a sequence of calculations.
 	 */
-	private static final RoundingMode DEFAULT_PRECISION_ROUNDING_MODE = RoundingMode.HALF_EVEN;
+	private static RoundingMode ROUNDING_MODE = RoundingMode.HALF_EVEN;
 
 	// Internal fields
 
 	private Double value;
-
-	/**
-	 * MathContext of value.
-	 */
-	private static MathContext precisionMathContext = new MathContext(DEFAULT_MAX_PRECISION,
-			DEFAULT_PRECISION_ROUNDING_MODE);
 
 	// Constructors
 
@@ -57,8 +51,7 @@ public class DoubleProbabilityNumber implements ProbabilityNumber, Comparable<Pr
 	 */
 	public DoubleProbabilityNumber(double value) {
 		if (value < 0 || value > 1) {
-			// Probability value must between 0 and 1
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("Probability value must be between 0 and 1");
 		}
 		this.value = value;
 	}
@@ -72,10 +65,235 @@ public class DoubleProbabilityNumber implements ProbabilityNumber, Comparable<Pr
 	 */
 	public DoubleProbabilityNumber(BigDecimal value) {
 		if (null == value || value.compareTo(new BigDecimal(0)) == -1 || value.compareTo(new BigDecimal(1)) == 1) {
-			// Probability value must between 0 and 1
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("Probability value must be between 0 and 1");
 		}
 		this.value = value.doubleValue();
+	}
+
+	// Public methods
+
+	/**
+	 * The BigDecimal value returned represents the double value represented by
+	 * this class with MAX_PRECISION.
+	 * 
+	 * @return value of BigDecimal type.
+	 */
+	@Override
+	public BigDecimal getValue() {
+		return new BigDecimal(this.value, this.getMathContext());
+	}
+
+	/**
+	 * @return MathContext set to DECIMAL64 - 1 (15 digits) precision and
+	 *         HALF_EVEN RoundingMode by default.
+	 */
+	@Override
+	public MathContext getMathContext() {
+		return new MathContext(MAX_PRECISION, ROUNDING_MODE);
+	}
+
+	/**
+	 * Checks if the value is zero or not.
+	 * 
+	 * @return true if zero, false otherwise.
+	 */
+	@Override
+	public boolean isZero() {
+		return (compareDouble(this.value, 0) == 0);
+	}
+
+	/**
+	 * Checks if the value is one or not.
+	 * 
+	 * @return true if one, false otherwise.
+	 */
+	@Override
+	public boolean isOne() {
+		return (compareDouble(this.value, 1) == 0);
+	}
+
+	/**
+	 * Checks if the probability value represented is valid i.e it falls within
+	 * the range [0, 1]. It is possible for operations on ProbabilityNumber
+	 * instances to cause the result to either overflow or underflow the range
+	 * [0, 1].
+	 * 
+	 * @return true if a valid probability value, false otherwise.
+	 */
+	@Override
+	public boolean isValid() {
+		return (compareDouble(this.value, 0) >= 0 && compareDouble(this.value, 1) <= 0);
+	}
+
+	/**
+	 * Add a DoubleProbabilityNumber to this DoubleProbabilityNumber and return
+	 * a new DoubleProbabilityNumber.
+	 * 
+	 * @param that
+	 *            the DoubleProbabilityNumber that is to be added to this
+	 *            DoubleProbabilityNumber.
+	 * 
+	 * @return a new DoubleProbabilityNumber that is the result of addition.
+	 */
+	@Override
+	public ProbabilityNumber add(ProbabilityNumber that) {
+		DoubleProbabilityNumber addend = toInternalType(that);
+		return new DoubleProbabilityNumber(this.value + addend.value);
+	}
+
+	/**
+	 * Subtract a DoubleProbabilityNumber from this DoubleProbabilityNumber and
+	 * return a new DoubleProbabilityNumber.
+	 * 
+	 * @param that
+	 *            the DoubleProbabilityNumber that is to be subtracted from this
+	 *            DoubleProbabilityNumber.
+	 * 
+	 * @return a new DoubleProbabilityNumber that is the result of subtraction
+	 */
+	@Override
+	public ProbabilityNumber subtract(ProbabilityNumber that) {
+		DoubleProbabilityNumber subtrahend = toInternalType(that);
+		return new DoubleProbabilityNumber(this.value - subtrahend.value);
+	}
+
+	/**
+	 * Multiply a DoubleProbabilityNumber with this DoubleProbabilityNumber and
+	 * return a new DoubleProbabilityNumber.
+	 * 
+	 * @param that
+	 *            the DoubleProbabilityNumber that is to be multiplied to this
+	 *            DoubleProbabilityNumber.
+	 * 
+	 * @result a new DoubleProbabilityNumber that is the result of
+	 *         multiplication.
+	 */
+	@Override
+	public ProbabilityNumber multiply(ProbabilityNumber that) {
+		DoubleProbabilityNumber multiplier = toInternalType(that);
+		return new DoubleProbabilityNumber(this.value * multiplier.value);
+	}
+
+	/**
+	 * Divide a DoubleProbabilityNumber with this DoubleProbabilityNumber and
+	 * return a new DoubleProbabilityNumber.
+	 * 
+	 * @param that
+	 *            the DoubleProbabilityNumber that is the divisor of this
+	 *            DoubleProbabilityNumber.
+	 * 
+	 * @return a new DoubleProbabilityNumber that is the result of division.
+	 */
+	@Override
+	public ProbabilityNumber divide(ProbabilityNumber that) {
+		DoubleProbabilityNumber divisor = toInternalType(that);
+		if (divisor.isZero()) {
+			throw new IllegalArgumentException("Division by 0 not allowed");
+		}
+		return new DoubleProbabilityNumber(this.value / divisor.value);
+	}
+
+	/**
+	 * Calculate the DoubleProbabilityNumber raised to an integer exponent.
+	 * 
+	 * @param exponent
+	 *            of integer type.
+	 * 
+	 * @result a new DoubleProbabilityNumber that is this
+	 *         DoubleProbabilityNumber raised to the exponent value.
+	 */
+	@Override
+	public ProbabilityNumber pow(int exponent) {
+		return new DoubleProbabilityNumber(Math.pow(this.value, exponent));
+	}
+
+	/**
+	 * Calculate the DoubleProbabilityNumber raised to a BigInteger exponent. If
+	 * the value of the BigInteger is greater than that representable by integer
+	 * type, then the lower order 32 bits are chosen by default.
+	 * 
+	 * @param exponent
+	 *            of BigInteger type.
+	 * 
+	 * @result a new DoubleProbabilityNumber that is this
+	 *         DoubleProbabilityNumber raised to the exponent value.
+	 */
+	@Override
+	public ProbabilityNumber pow(BigInteger exponent) {
+		return new DoubleProbabilityNumber(Math.pow(this.value, exponent.intValue()));
+	}
+
+	/**
+	 * Sum all elements implementing ProbabilityNumber stored in an Iterable
+	 * object.
+	 * 
+	 * @param allProbabilities
+	 *            an iterable object containing elements of type
+	 *            ProbabilityNumber.
+	 * 
+	 * @return true if sum of all elements constituting the iterable sum to one,
+	 *         false otherwise.
+	 */
+	@Override
+	public boolean sumsToOne(Iterable<ProbabilityNumber> allProbabilities) {
+		DoubleProbabilityNumber sumOfProbabilities = new DoubleProbabilityNumber(0);
+		for (ProbabilityNumber probability : allProbabilities) {
+			DoubleProbabilityNumber specificType = toInternalType(probability);
+			sumOfProbabilities = (DoubleProbabilityNumber) (sumOfProbabilities.add(specificType));
+		}
+		return this.isOne();
+	}
+
+	/**
+	 * Override the precision of ProbabilityNumber instances returned as a
+	 * result of performing operations.
+	 * 
+	 * @param mc
+	 */
+	@Override
+	public void overrideComputationPrecisionGlobally(MathContext mc) {
+		if (mc.getPrecision() > 15) {
+			throw new IllegalArgumentException("Maximum precision possible for DoubleProbabilityNumber is 15");
+		}
+		MAX_PRECISION = mc.getPrecision();
+		ROUNDING_MODE = mc.getRoundingMode();
+	}
+
+	/**
+	 * Checks if argument implementing ProbabilityNumber interface is equal to
+	 * the value of the current DoubleProbabilityNumber.
+	 * 
+	 * @param that
+	 *            the ProbabilityNumber type that is to be compared with this
+	 *            DoubleProbabilityNumber.
+	 *
+	 * @return true if this == that, false otherwise
+	 */
+	@Override
+	public boolean equals(Object that) {
+		DoubleProbabilityNumber second = toInternalType((ProbabilityNumber) that);
+		return (compareDouble(this.value, second.value) == 0);
+	}
+
+	/**
+	 * Compare this with another ProbabilityNumber value (that).
+	 * 
+	 * @param that
+	 *            of type ProbabilityNumber.
+	 * 
+	 * @return 1 if this > that, 0 if this == that, -1 if this < that.
+	 */
+	@Override
+	public int compareTo(ProbabilityNumber that) {
+		DoubleProbabilityNumber second = toInternalType(that);
+		return compareDouble(this.value, second.value);
+	}
+
+	/**
+	 * @return string representation of value.
+	 */
+	public String toString() {
+		return getValue().toString();
 	}
 
 	// Private methods
@@ -117,199 +335,5 @@ public class DoubleProbabilityNumber implements ProbabilityNumber, Comparable<Pr
 		} else {
 			return ((first > second) ? 1 : -1);
 		}
-	}
-
-	// Public methods
-
-	/**
-	 * @return value of BigDecimal type.
-	 */
-	@Override
-	public BigDecimal getValue() {
-		return new BigDecimal(value, precisionMathContext);
-	}
-
-	/**
-	 * @return precisionMathContext set to DECIMAL64 - 1 (15 digits) precision
-	 *         and HALF_EVEN RoundingMode by default.
-	 */
-	@Override
-	public MathContext getMathContext() {
-		return precisionMathContext;
-	}
-
-	/**
-	 * Checks if the value is zero or not.
-	 * 
-	 * @return true if zero, false otherwise.
-	 */
-	@Override
-	public boolean isZero() {
-		return (compareDouble(this.value, 0) == 0);
-	}
-
-	/**
-	 * Checks if the value is one or not.
-	 * 
-	 * @return true if one, false otherwise.
-	 */
-	@Override
-	public boolean isOne() {
-		return (compareDouble(this.value, 1) == 0);
-	}
-
-	/**
-	 * Checks if argument implementing ProbabilityNumber interface is equal to
-	 * the value of the current DoubleProbabilityNumber.
-	 * 
-	 * @param that
-	 *            the ProbabilityNumber type that is to be compared with this
-	 *            DoubleProbabilityNumber.
-	 *
-	 * @return true if this == that, false otherwise
-	 */
-	@Override
-	public boolean equals(ProbabilityNumber that) {
-		DoubleProbabilityNumber second = toInternalType(that);
-		return (compareDouble(this.value, second.value) == 0);
-	}
-
-	/**
-	 * Compare this with another ProbabilityNumber value (that).
-	 * 
-	 * @param that
-	 *            of type ProbabilityNumber.
-	 * 
-	 * @return 1 if this > that, 0 if this == that, -1 if this < that.
-	 */
-	@Override
-	public int compareTo(ProbabilityNumber that) {
-		DoubleProbabilityNumber second = toInternalType(that);
-		return compareDouble(this.value, second.value);
-	}
-
-	/**
-	 * Add a DoubleProbabilityNumber to this DoubleProbabilityNumber and return
-	 * a new DoubleProbabilityNumber.
-	 * 
-	 * @param that
-	 *            the DoubleProbabilityNumber that is to be added to this
-	 *            DoubleProbabilityNumber.
-	 * 
-	 * @return a new DoubleProbabilityNumber that is the result of addition.
-	 */
-	@Override
-	public ProbabilityNumber add(ProbabilityNumber that) {
-		DoubleProbabilityNumber addend = toInternalType(that);
-		return new DoubleProbabilityNumber(value + addend.value);
-	}
-
-	/**
-	 * Subtract a DoubleProbabilityNumber from this DoubleProbabilityNumber and
-	 * return a new DoubleProbabilityNumber.
-	 * 
-	 * @param that
-	 *            the DoubleProbabilityNumber that is to be subtracted from this
-	 *            DoubleProbabilityNumber.
-	 * 
-	 * @return a new DoubleProbabilityNumber that is the result of subtraction
-	 */
-	@Override
-	public ProbabilityNumber subtract(ProbabilityNumber that) {
-		DoubleProbabilityNumber subtrahend = toInternalType(that);
-		// Should value be checked for being negative? In intermediate
-		// computations, values may become negative temporarily
-		return new DoubleProbabilityNumber(value - subtrahend.value);
-	}
-
-	/**
-	 * Multiply a DoubleProbabilityNumber with this DoubleProbabilityNumber and
-	 * return a new DoubleProbabilityNumber.
-	 * 
-	 * @param that
-	 *            the DoubleProbabilityNumber that is to be multiplied to this
-	 *            DoubleProbabilityNumber.
-	 * 
-	 * @result a new DoubleProbabilityNumber that is the result of
-	 *         multiplication.
-	 */
-	@Override
-	public ProbabilityNumber multiply(ProbabilityNumber that) {
-		DoubleProbabilityNumber multiplier = toInternalType(that);
-		return new DoubleProbabilityNumber(value * multiplier.value);
-	}
-
-	/**
-	 * Divide a DoubleProbabilityNumber with this DoubleProbabilityNumber and
-	 * return a new DoubleProbabilityNumber.
-	 * 
-	 * @param that
-	 *            the DoubleProbabilityNumber that is the divisor of this
-	 *            DoubleProbabilityNumber.
-	 * 
-	 * @return a new DoubleProbabilityNumber that is the result of division.
-	 */
-	@Override
-	public ProbabilityNumber divide(ProbabilityNumber that) {
-		DoubleProbabilityNumber divisor = toInternalType(that);
-		if (divisor.isZero()) {
-			throw new IllegalArgumentException();
-		}
-		return new DoubleProbabilityNumber(value / divisor.value);
-	}
-
-	/**
-	 * Calculate the DoubleProbabilityNumber raised to an integer exponent.
-	 * 
-	 * @param exponent
-	 *            of integer type.
-	 * 
-	 * @result a new DoubleProbabilityNumber that is this
-	 *         DoubleProbabilityNumber raised to the exponent value.
-	 */
-	@Override
-	public ProbabilityNumber pow(int exponent) {
-		return new DoubleProbabilityNumber(Math.pow(value, exponent));
-	}
-
-	/**
-	 * Calculate the DoubleProbabilityNumber raised to a BigInteger exponent. If
-	 * the value of the BigInteger is greater than that representable by integer
-	 * type, then the lower order 32 bits are chosen by default.
-	 * 
-	 * @param exponent
-	 *            of BigInteger type.
-	 * 
-	 * @result a new DoubleProbabilityNumber that is this
-	 *         DoubleProbabilityNumber raised to the exponent value.
-	 */
-	@Override
-	public ProbabilityNumber pow(BigInteger exponent) {
-		return new DoubleProbabilityNumber(Math.pow(value, exponent.intValue()));
-	}
-
-	/**
-	 * Sum all elements implementing ProbabilityNumber stored in an Iterable
-	 * object.
-	 * 
-	 * @param allProbabilities
-	 *            an iterable object containing elements of type
-	 *            ProbabilityNumber.
-	 * 
-	 * @return true if sum of all elements constituting the iterable sum to one,
-	 *         false otherwise.
-	 */
-	@Override
-	public boolean sumsToOne(Iterable<ProbabilityNumber> allProbabilities) {
-		DoubleProbabilityNumber sumOfProbabilities = new DoubleProbabilityNumber(0);
-		for (ProbabilityNumber probability : allProbabilities) {
-			DoubleProbabilityNumber specificType = toInternalType(probability);
-			sumOfProbabilities = (DoubleProbabilityNumber) (sumOfProbabilities.add(specificType));
-		}
-		return this.isOne();
-	}
-
-	public String toString() {
-		return getValue().toString();
 	}
 }

--- a/extra/src/main/java/aima/extra/probability/ProbabilityNumber.java
+++ b/extra/src/main/java/aima/extra/probability/ProbabilityNumber.java
@@ -6,9 +6,15 @@ import java.math.MathContext;
 
 /**
  * ProbabilityNumber interface defines arithmetic specifically for probability
- * values. A probability value is quantified between 0 and 1. Operations that
- * violate the property of a probability value are not permitted. This interface
- * is implemented by the various ProbabilityNumber implementations.
+ * values. A probability value is quantified between 0 and 1. Although a
+ * ProbabilityNumber cannot be initialised with a value outside the bounds [0,
+ * 1], operations may cause the value represented to exceed these bounds. It is
+ * therefore necessary to validate the result obtained from a series of
+ * computations to ensure that the result is a valid probability value. This
+ * interface is implemented by the various ProbabilityNumber implementations.
+ * 
+ * The interface is intended to be immutable. Implementations may implement
+ * overriden versions of equals and hashcode methods.
  * 
  * @author Nagaraj Poti
  *
@@ -24,32 +30,41 @@ public interface ProbabilityNumber extends Comparable<ProbabilityNumber> {
 	BigDecimal getValue();
 
 	/**
+	 * Precision (def.) - the number of significant digits (Zero before decimal
+	 * point does not contribute to the precision count)<br>
+	 * 
+	 * <br>
 	 * Get the MathContext object associated with the ProbabilityNumber object.
 	 * MathContext can be set for BigDecimalProbabilityNumber and
-	 * RationalProbabilityNumber via the constructor mechanism. The default
-	 * MathContext object associated with the implementations is of DECIMAL128
-	 * precision. It is possible to go upto an even higher precision all the way
-	 * upto UNLIMITED setting.
+	 * RationalProbabilityNumber instances via the constructor mechanism. The
+	 * precision of the result of a computation is specified by the precision of
+	 * the operands (default) or can be arbitrarily specified all the way upto
+	 * the highest precision defined by the UNLIMITED setting (overriding
+	 * default behaviour).<br>
 	 * 
+	 * <br>
 	 * UNLIMITED - A MathContext object whose settings have the values required
 	 * for unlimited precision arithmetic. The values of the settings are:
 	 * precision=0 and roundingMode=HALF_UP (ignored in this case). When a
 	 * MathContext object is supplied with a precision setting of 0
-	 * (MathContext.UNLIMITED), arithmetic operations are exact. In the case of
-	 * divide, the exact quotient could have an infinitely long decimal
-	 * expansion; for example, 1 divided by 3. If the quotient has a
-	 * nonterminating decimal expansion and the operation is specified to return
-	 * an exact result, an ArithmeticException is thrown. Otherwise, the exact
-	 * result of the division is returned, as done for other operations.
+	 * (MathContext.UNLIMITED), results of arithmetic operations returned are
+	 * exact. In the case of division, the exact quotient could have an
+	 * infinitely long decimal expansion; for example, 1 divided by 3. If the
+	 * quotient has a nonterminating decimal expansion and the operation is
+	 * specified to return an exact result, an ArithmeticException is thrown.
+	 * Otherwise, the exact result of the division is returned, as done for
+	 * other operations.<br>
 	 * 
-	 * The rounding modes and precision setting determine how operations return
-	 * results with a limited number of digits when the exact result has more
-	 * digits than the number of digits returned. First, the total number of
-	 * digits to return is specified by the MathContext's precision setting;
-	 * this determines the result's precision. The digit count starts from the
+	 * <br>
+	 * The rounding modes and precisions determine how operations return results
+	 * with a limited number of digits when the exact result has more digits
+	 * than the number of digits returned. The total number of digits returned
+	 * is determined by (i.e min(operand_1_precision, operand_2_precision) + 1);
+	 * this behaviour can however be overriden. The digit count starts from the
 	 * leftmost nonzero digit of the exact result. The rounding mode determines
-	 * how any discarded trailing digits affect the returned result.
+	 * how any discarded trailing digits affect the returned result.<br>
 	 * 
+	 * <br>
 	 * For all arithmetic operators, the operation is carried out as though an
 	 * exact intermediate result were first calculated and then rounded to the
 	 * number of digits specified by the precision setting (if necessary), using
@@ -74,48 +89,56 @@ public interface ProbabilityNumber extends Comparable<ProbabilityNumber> {
 	boolean isOne();
 
 	/**
-	 * Check if two ProbabilityNumber values are equal.
+	 * Checks if the probability value represented is valid i.e it falls within
+	 * the range [0, 1]. It is possible for operations on ProbabilityNumber
+	 * instances to cause the result to either overflow or underflow the range
+	 * [0, 1].
 	 * 
-	 * @param that
-	 *            is a ProbabilityNumber.
-	 * 
-	 * @return true if equal, false otherwise.
+	 * @return true if a valid probability value, false otherwise.
 	 */
-	boolean equals(ProbabilityNumber that);
+	boolean isValid();
 
 	/**
-	 * Add two ProbabilityNumber types and return a ProbabilityNumber.
+	 * Add two ProbabilityNumber types and return a new ProbabilityNumber
+	 * representing the result of addition.
 	 * 
 	 * @param addend
 	 * 
-	 * @return result of addition of two ProbabilityNumber types.
+	 * @return a new ProbabilityNumber representing the result of addition of
+	 *         two ProbabilityNumber types.
 	 */
 	ProbabilityNumber add(ProbabilityNumber addend);
 
 	/**
-	 * Subtract two ProbabilityNumber types and return a ProbabilityNumber.
+	 * Subtract two ProbabilityNumber types and return a new ProbabilityNumber
+	 * representing the result of subtraction.
 	 * 
 	 * @param subtrahend
 	 * 
-	 * @return result of subtraction of two ProbabilityNumber types.
+	 * @return a new ProbabilityNumber representing the result of subtraction of
+	 *         two ProbabilityNumber types.
 	 */
 	ProbabilityNumber subtract(ProbabilityNumber subtrahend);
 
 	/**
-	 * Multiply two ProbabilityNumber types and return a ProbabilityNumber.
+	 * Multiply two ProbabilityNumber types and return a new ProbabilityNumber
+	 * representing the result of multiplication.
 	 * 
 	 * @param multiplicand
 	 * 
-	 * @return result of multiplication of two ProbabilityNumber types.
+	 * @return a new ProbabilityNumber representing the result of multiplication
+	 *         of two ProbabilityNumber types.
 	 */
 	ProbabilityNumber multiply(ProbabilityNumber multiplicand);
 
 	/**
-	 * Divide two ProbabilityNumber types and return a ProbabilityNumber.
+	 * Divide two ProbabilityNumber types and return a ProbabilityNumber
+	 * representing the result of division.
 	 * 
 	 * @param divisor
 	 * 
-	 * @return result of division of two ProbabilityNumber types.
+	 * @return a new ProbabilityNumber representing the result of division of
+	 *         two ProbabilityNumber types.
 	 */
 	ProbabilityNumber divide(ProbabilityNumber divisor);
 
@@ -124,7 +147,8 @@ public interface ProbabilityNumber extends Comparable<ProbabilityNumber> {
 	 * 
 	 * @param exponent
 	 * 
-	 * @return result of exponentiation.
+	 * @return a new ProbabilityNumber representing the result of
+	 *         exponentiation.
 	 */
 	ProbabilityNumber pow(int exponent);
 
@@ -133,7 +157,8 @@ public interface ProbabilityNumber extends Comparable<ProbabilityNumber> {
 	 * 
 	 * @param exponent
 	 * 
-	 * @return result of exponentiation.
+	 * @return a new ProbabilityNumber representing the result of
+	 *         exponentiation.
 	 */
 	ProbabilityNumber pow(BigInteger exponent);
 
@@ -146,4 +171,12 @@ public interface ProbabilityNumber extends Comparable<ProbabilityNumber> {
 	 * @return true if the probabilities sum to one, false otherwise.
 	 */
 	boolean sumsToOne(Iterable<ProbabilityNumber> allProbabilities);
+
+	/**
+	 * Override the precision of ProbabilityNumber instances returned as a
+	 * result of performing operations.
+	 * 
+	 * @param mc
+	 */
+	void overrideComputationPrecisionGlobally(MathContext mc);
 }

--- a/test/src/test/java/aima/test/unit/probability/BigDecimalTypeTest.java
+++ b/test/src/test/java/aima/test/unit/probability/BigDecimalTypeTest.java
@@ -24,62 +24,70 @@ public class BigDecimalTypeTest {
 
 		ProbabilityNumber testValue2 = ProbabilityFactory.decimalValueOf(0.15);
 
-		// Get BigDecimal value
-		System.out.println(testValue2.getValue());
-
 		ProbabilityNumber testValue0 = ProbabilityFactory.decimalValueOf(new BigDecimal("0.000"));
 		// Check if zero
 		assertEquals(testValue0.isZero(), true);
 
 		ProbabilityNumber testValue1 = ProbabilityFactory.decimalValueOf(
-				new BigDecimal("0.99999999999999999999999999999999999"));
+				new BigDecimal("1.000000"));
 		// Check if one
 		assertEquals(testValue1.isOne(), true);
 
 		ProbabilityNumber testValue4 = ProbabilityFactory.decimalValueOf(
-				new BigDecimal("0.15000000000000000000000000000000001"));
+				new BigDecimal("0.15000000000000000000000"));
 		// Check if two DoubleProbabilityNumber values are equal or not
 		assertEquals(testValue2.equals(testValue4), true);
 
 		ProbabilityNumber testValue5 = ProbabilityFactory.decimalValueOf(0.1);
 		ProbabilityNumber testValue6 = ProbabilityFactory.decimalValueOf(0.8);
-
+		
+		BigDecimal v2 = BigDecimal.valueOf(0.15);
+		BigDecimal v5 = BigDecimal.valueOf(0.1);
+		BigDecimal v6 = BigDecimal.valueOf(0.8);
+		
 		// Add DoubleProbabilityNumber values
-		assertEquals(0.15 + 0.1, testValue2.add(testValue5).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
-		assertEquals(0.8 + 0.15, testValue6.add(testValue2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(v2.add(v5).doubleValue(), testValue2.add(testValue5).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(v6.add(v2).doubleValue(), testValue6.add(testValue2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 
 		// Subtract DoubleProbabilityNumber values
-		assertEquals(0.15 - 0.1, testValue2.subtract(testValue5).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
-		assertEquals(0.8 - 0.15, testValue6.subtract(testValue2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(v2.subtract(v5).doubleValue(), testValue2.subtract(testValue5).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(v6.subtract(v2).doubleValue(), testValue6.subtract(testValue2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 
 		// Multiply DoubleProbabilityNumber values
-		assertEquals(0.15 * 0.1, testValue2.multiply(testValue5).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
-		assertEquals(0.8 * 0.15, testValue6.multiply(testValue2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(v2.multiply(v5).doubleValue(), testValue2.multiply(testValue5).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(v6.multiply(v2).doubleValue(), testValue6.multiply(testValue2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 
 		// Divide DoubleProbabilityNumber values
-		assertEquals(0.15 / 0.8, testValue2.divide(testValue6).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(0.19, testValue2.divide(testValue6).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 
 		/*
 		// Unlimited precision (non terminating decimal value)
 		ProbabilityNumber t1 = ProbabilityFactory.decimalValueOf(new BigDecimal("0.1"), 0);
 		ProbabilityNumber t2 = ProbabilityFactory.decimalValueOf(new BigDecimal("0.3"), 0);
+		t1.overrideComputationPrecisionGlobally(MathContext.UNLIMITED);
 		assertEquals(0.1 / 0.3, t1.divide(t2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
-		System.out.println(t1.divide(t2).getValue());
+		*/
+		
+		/* 
+		// BigDecimal instances can be initialized with values using different constructors. 
+		// The MathContext objects that may be explicitly specified during constructor call
+		// are treated by the BigDecimal class in different ways. 
+		BigDecimal n = new BigDecimal("1.3000000000", new MathContext(5, RoundingMode.HALF_EVEN));
+		System.out.println(n.precision());
 		*/
 		
 		// Check for computations with different precision values
-		ProbabilityNumber t1 = ProbabilityFactory.decimalValueOf(new BigDecimal("0.1"), 0);
-		ProbabilityNumber t2 = ProbabilityFactory.decimalValueOf(new BigDecimal("0.3"));
-		assertEquals(0.1 / 0.3, t1.divide(t2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
-		System.out.println(t1.divide(t2).getValue());
+		ProbabilityNumber t1 = ProbabilityFactory.decimalValueOf(new BigDecimal(0.1), 3);
+		ProbabilityNumber t2 = ProbabilityFactory.decimalValueOf(new BigDecimal(0.3), 5);
+		assertEquals(0.3333, t1.divide(t2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 		
 		// Raise DoubleProbabilityNumber values to powers (check for boundary
 		// conditions
 		// (positive infinity, negative infinity))
 		assertEquals(0.15 * 0.15, testValue2.pow(2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
-		assertEquals(0.8 * 0.8 * 0.8, testValue6.pow(3).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(0.51, testValue6.pow(3).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 
-		System.out.println(testValue2.pow(BigInteger.valueOf(20)).getValue());
+		// System.out.println(testValue2.pow(BigInteger.valueOf(20)).getValue());
 
 		/**
 		 * Computation to test number representation precision
@@ -89,7 +97,7 @@ public class BigDecimalTypeTest {
 		double a = 0.005;
 		double b = 0.0049;
 		// Note the slight precision loss
-		System.out.println("double representation -> " + (a - b));
+		// System.out.println("double representation -> " + (a - b));
 		// Accurate value when using string constructors
 		ProbabilityNumber a1 = ProbabilityFactory.decimalValueOf(new BigDecimal("0.005"));
 		ProbabilityNumber a2 = ProbabilityFactory.decimalValueOf(new BigDecimal("0.0049"));
@@ -97,16 +105,18 @@ public class BigDecimalTypeTest {
 		// for the inaccuracy
 		ProbabilityNumber b1 = ProbabilityFactory.decimalValueOf(new BigDecimal(a));
 		ProbabilityNumber b2 = ProbabilityFactory.decimalValueOf(new BigDecimal(b));
-		System.out.println("String constructor initialised -> " + a1.subtract(a2).getValue().doubleValue());
-		System.out.println("Double constructor initialised -> " + b1.subtract(b2).getValue().doubleValue());
-
+		// System.out.println("String constructor initialised -> " + a1.subtract(a2).getValue().doubleValue());
+		// System.out.println("Double constructor initialised -> " + b1.subtract(b2).getValue().doubleValue());
+		assertEquals(0.0001, a1.subtract(a2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(0.0001, b1.subtract(b2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		
 		// Raise BigDecimalProbabilityNumber values to powers
-		ProbabilityNumber v1 = ProbabilityFactory.decimalValueOf(new BigDecimal("0.6"));
-		ProbabilityNumber v2 = ProbabilityFactory.decimalValueOf(new BigDecimal(0.1));
-		assertEquals(0.6 * 0.6, v1.pow(2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
-		assertEquals(0.1 * 0.1 * 0.1 * 0.1 * 0.1, v2.pow(5).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		ProbabilityNumber c1 = ProbabilityFactory.decimalValueOf(new BigDecimal("0.6"));
+		ProbabilityNumber c2 = ProbabilityFactory.decimalValueOf(new BigDecimal(0.1));
+		assertEquals(0.6 * 0.6, c1.pow(2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(0.1 * 0.1 * 0.1 * 0.1 * 0.1, c2.pow(5).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 		// BigDecimal uses integer scale internally, thus scale value cannot
 		// exceed beyond the integer range
-		System.out.println("Power -> " + v1.pow(BigInteger.valueOf(1000000000L)).getValue());
+		// System.out.println("Power -> " + c1.pow(BigInteger.valueOf(1000000000L)).getValue());
 	}
 }

--- a/test/src/test/java/aima/test/unit/probability/DoubleTypeTest.java
+++ b/test/src/test/java/aima/test/unit/probability/DoubleTypeTest.java
@@ -2,7 +2,6 @@ package aima.test.unit.probability;
 
 import aima.extra.probability.*;
 import static org.junit.Assert.*;
-import java.math.BigInteger;
 import org.junit.Test;
 
 public class DoubleTypeTest {
@@ -24,7 +23,7 @@ public class DoubleTypeTest {
 		ProbabilityNumber testValue2 = ProbabilityFactory.doubleValueOf(0.15);
 
 		// Get BigDecimal value
-		System.out.println(testValue2.getValue());
+		// System.out.println(testValue2.getValue());
 		
 		ProbabilityNumber testValue0 = ProbabilityFactory.doubleValueOf(0.00000001);
 		// Check if zero
@@ -61,6 +60,6 @@ public class DoubleTypeTest {
 		assertEquals(0.15 * 0.15, testValue2.pow(2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 		assertEquals(0.8 * 0.8 * 0.8, testValue6.pow(3).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 		
-		System.out.println(testValue2.pow(BigInteger.valueOf(20)).getValue());
+		// System.out.println(testValue2.pow(BigInteger.valueOf(20)).getValue());
 	}
 }

--- a/test/src/test/java/aima/test/unit/probability/LogTypeTest.java
+++ b/test/src/test/java/aima/test/unit/probability/LogTypeTest.java
@@ -2,7 +2,6 @@ package aima.test.unit.probability;
 
 import aima.extra.probability.*;
 import static org.junit.Assert.*;
-import java.math.BigInteger;
 import org.junit.Test;
 
 public class LogTypeTest {
@@ -21,7 +20,7 @@ public class LogTypeTest {
 		ProbabilityNumber testValue2 = ProbabilityFactory.logValueOf(0.15);
 
 		// Get BigDecimal value
-		System.out.println(testValue2.getValue());
+		// System.out.println(testValue2.getValue());
 		
 		ProbabilityNumber testValue0 = ProbabilityFactory.logValueOf(0.00000001);
 		// Check if zero
@@ -56,6 +55,6 @@ public class LogTypeTest {
 		assertEquals(0.15 * 0.15, testValue2.pow(2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 		assertEquals(0.8 * 0.8 * 0.8, testValue6.pow(3).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 		
-		System.out.println(testValue2.pow(BigInteger.valueOf(20)).getValue());
+		// System.out.println(testValue2.pow(BigInteger.valueOf(20)).getValue());
 	}
 }

--- a/test/src/test/java/aima/test/unit/probability/RationalTypeTest.java
+++ b/test/src/test/java/aima/test/unit/probability/RationalTypeTest.java
@@ -2,9 +2,7 @@ package aima.test.unit.probability;
 
 import aima.extra.probability.*;
 import static org.junit.Assert.*;
-
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import org.junit.Test;
 
 public class RationalTypeTest {
@@ -24,10 +22,10 @@ public class RationalTypeTest {
 		ProbabilityNumber testValue2 = ProbabilityFactory.rationalValueOf(new BigDecimal("0.15"));
 
 		// Get BigDecimal value
-		System.out.println(testValue2.getValue());
+		// System.out.println(testValue2.getValue());
 
-		System.out.println("Numerator -> " + ((RationalProbabilityNumber) testValue2).getNumerator());
-		System.out.println("Denominator -> " + ((RationalProbabilityNumber) testValue2).getDenominator());
+		// System.out.println("Numerator -> " + ((RationalProbabilityNumber) testValue2).getNumerator());
+		// System.out.println("Denominator -> " + ((RationalProbabilityNumber) testValue2).getDenominator());
 		
 		ProbabilityNumber testValue0 = ProbabilityFactory.rationalValueOf(new BigDecimal("0.000"));
 		// Check if zero
@@ -64,7 +62,7 @@ public class RationalTypeTest {
 		assertEquals(0.15 * 0.15, testValue2.pow(2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 		assertEquals(0.8 * 0.8 * 0.8, testValue6.pow(3).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 		
-		System.out.println(testValue2.pow(BigInteger.valueOf(20)).getValue());
+		// System.out.println(testValue2.pow(BigInteger.valueOf(20)).getValue());
 	
 		/**
 		 * Computation to test number representation precision
@@ -74,7 +72,7 @@ public class RationalTypeTest {
 		double a = 0.005;
 		double b = 0.0049;
 		// Note the slight precision loss
-		System.out.println("double representation -> " + (a - b));
+		// System.out.println("double representation -> " + (a - b));
 		// Accurate value when using string constructors
 		ProbabilityNumber a1 = ProbabilityFactory.rationalValueOf(new BigDecimal("0.005"));
 		ProbabilityNumber a2 = ProbabilityFactory.rationalValueOf(new BigDecimal("0.0049"));
@@ -82,11 +80,11 @@ public class RationalTypeTest {
 		// for the inaccuracy
 		ProbabilityNumber b1 = ProbabilityFactory.rationalValueOf(new BigDecimal(a));
 		ProbabilityNumber b2 = ProbabilityFactory.rationalValueOf(new BigDecimal(b));
-		System.out.println(
-				"String constructor initialised -> " + a1.subtract(a2).getValue().doubleValue());
-		System.out.println(
-				"Double constructor initialised -> " + b1.subtract(b2).getValue().doubleValue());
-
+		// System.out.println("String constructor initialised -> " + a1.subtract(a2).getValue().doubleValue());
+		// System.out.println("Double constructor initialised -> " + b1.subtract(b2).getValue().doubleValue());
+		assertEquals(0.0001, a1.subtract(a2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		assertEquals(0.0001, b1.subtract(b2).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
+		
 		// Raise RationalProbabilityNumber values to powers
 		ProbabilityNumber v1 = ProbabilityFactory.rationalValueOf(6, 10);
 
@@ -95,6 +93,6 @@ public class RationalTypeTest {
 		assertEquals(0.1 * 0.1 * 0.1 * 0.1 * 0.1, v2.pow(5).getValue().doubleValue(), DEFAULT_ROUNDING_THRESHOLD);
 		// BigDecimal uses integer scale internally, thus scale value cannot
 		// exceed beyond the integer range
-		System.out.println("Power -> " + v1.pow(BigInteger.valueOf(4L)).getValue());
+		// System.out.println("Power -> " + v1.pow(BigInteger.valueOf(4L)).getValue());
 	}
 }


### PR DESCRIPTION
Made changes that were mentioned in the previous pull request as well added code corresponding to last discussion. 

Added a method to check whether the value held by the ProbabilityNumber is valid or not (between 0 and 1). Improper computations may cause the value to exceed these bounds. If tight checks on these bounds are placed when performing a computation, intermediate computations would need to be arranged such that the result of any intermediate computation in the sequence always results in a valid probability value. 