### PR TITLE
Use method parameter instead of instance variable

### DIFF
--- a/core/src/main/java/aima/core/environment/vacuum/VEWorldState.java
+++ b/core/src/main/java/aima/core/environment/vacuum/VEWorldState.java
@@ -69,7 +69,7 @@ public class VEWorldState {
 	}
 	
 	public boolean isClean(String location) {
-		return locationLocalStateMap.get(currentLocation).status == VacuumEnvironment.Status.Clean;
+		return locationLocalStateMap.get(location).status == VacuumEnvironment.Status.Clean;
 	}
 
 	public boolean isAllClean() {


### PR DESCRIPTION
The method makes use of the instance variable of ```VEWorldState``` which currently executes correctly as the method is used in a single context: ```worldState.isClean(worldState.currentLocation)``` in ```NonDeterministicProblemFactory```, line 35. However, the method may not behave as intended when the ```location``` from an instance of ```VELocalState``` or ```VEPercept``` is passed as an argument. @norvig @ctjoreilly @RuedigerLunde Can you kindly review this and correct me if I am wrong?