### PR TITLE
Update .gitignore

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,6 +1,7 @@
 /bin/
 /build/
 /target/
+/out/
 *.iml
 .settings
 .gradle

--- a/extra/.gitignore
+++ b/extra/.gitignore
@@ -1,5 +1,6 @@
 .settings
 /bin/
 /build/
+/out/
 /.classpath
 /.project

--- a/gui/.gitignore
+++ b/gui/.gitignore
@@ -1,6 +1,7 @@
 /bin/
 /build/
 /target/
+/out/
 *.iml
 .settings
 .gradle

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,6 +1,7 @@
 /bin/
 /build/
 /target/
+/out/
 *.iml
 .settings
 .gradle


### PR DESCRIPTION
@norvig IntelliJ no longer shares output directory with the gradle build system. However, it is still possible to update `build.gradle` [configuration](https://youtrack.jetbrains.com/issue/IDEA-175172#comment=27-2351437) inorder to enforce the IDE to share the output directory, but it is not recommended as this is IDE's [intentional behavior](https://youtrack.jetbrains.com/issue/IDEA-175172). Updating .gitignore is the easier option.