### PR TITLE
Add implementation of Depth-First-Search for AIMA4e branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,19 @@ Java implementation of algorithms from Russell and Norvig's "Artificial Intellig
        </td>
    </tr>
    <tr>
-       <td>3?</td>
-       <td>??</td>
-       <td>Depth-first Search</td>
+       <td rowspan="3">3.?</td>
+       <td rowspan="3">??</td>
+       <td rowspan="3">Depth-first Search</td>
+       <td>
+       <a href="core/src/main/java/aima/core/search/basic/uninformed/DepthFirstSearch.java">DepthFirstSearch</a>
+       </td>
+   </tr>
+   <tr>
+       <td>
+       Alternative(s)
+       </td>
+   </tr>
+   <tr>
        <td>
        <a href="extra/src/main/java/aima/extra/search/pqueue/uninformed/DepthFirstQueueSearch.java">DepthFirstQueueSearch</a>
        </td>

--- a/core/src/main/java/aima/core/search/basic/uninformed/DepthFirstSearch.java
+++ b/core/src/main/java/aima/core/search/basic/uninformed/DepthFirstSearch.java
@@ -1,0 +1,126 @@
+package aima.core.search.basic.uninformed;
+
+import aima.core.search.api.Node;
+import aima.core.search.api.NodeFactory;
+import aima.core.search.api.Problem;
+import aima.core.search.api.SearchController;
+import aima.core.search.api.SearchForActionsFunction;
+import aima.core.search.basic.support.BasicNodeFactory;
+import aima.core.search.basic.support.BasicSearchController;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+
+/**
+ * <pre>
+ * function DEPTH-FIRST-SEARCH(problem) returns a solution, or failure
+ *   node &larr; a node with STATE = problem.INITIAL-STATE, PATH-COST=0
+ *   if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
+ *   frontier &larr; a LIFO queue with node as the only element
+ *   explored &larr; an empty set
+ *   loop do
+ *       if EMPTY?(frontier) then return failure
+ *       node &larr; POP(frontier) // chooses the deepest node in the frontier
+ *       add node.STATE to explored
+ *       for each action in problem.ACTIONS(node.STATE) do
+ *           child &larr; CHILD-NODE(problem, node, action)
+ *           if child.STATE is not in explored or frontier then
+ *               if problem.GOAL-TEST(child.STATE) then return SOLUTION(child)
+ *               frontier &larr; INSERT(child, frontier)
+ * </pre>
+ *
+ * <b>Figure ??</b> Depth-first graph search.
+ *
+ * <p>The depth-first search algorithm is an instance of the graph-search algorithm;
+ * whereas breadth-first search uses a FIFO queue, depth-first-search uses a LIFO
+ * queue which means that the most recently generated node is chosen for expansion.
+ * This must be the deepest unexpanded node when it was selected. The graph-search
+ * version avoids repeated states and redundant paths and is complete in finite
+ * state spaces because it will eventually expand every node. There is one slight
+ * tweak on the general graph-search algorithm, which is that the goal test is
+ * applied to each node when it is generated rather than when it is selected for
+ * expansion.
+ */
+public class DepthFirstSearch<A, S> implements SearchForActionsFunction<A, S> {
+  // function DEPTH-FIRST-SEARCH(problem) returns a solution, or failure
+  @Override
+  public List<A> apply(Problem<A, S> problem) {
+    // node <- a node with STATE = problem.INITIAL-STATE, PATH-COST=0
+    Node<A, S> node = newRootNode(problem.initialState(), 0);
+    // if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
+    if (isGoalState(node, problem)) {
+      return solution(node);
+    }
+    // frontier <- a LIFO queue with node as the only element
+    Queue<Node<A, S>> frontier = newLIFOQueue(node);
+    // explored <- an empty set
+    Set<S> explored = newExploredSet();
+    // loop do
+    while (true) {
+      // if EMPTY?(frontier) then return failure
+      if (frontier.isEmpty()) {
+        return failure();
+      }
+      // node <- POP(frontier) // chooses the deepest unexplored node in the frontier
+      node = frontier.remove();
+      // add node.STATE to explored
+      explored.add(node.state());
+      // for each action in problem.ACTIONS(node.STATE) do
+      for (A action : problem.actions(node.state())) {
+        // child <- CHILD-NODE(problem, node, action)
+        Node<A, S> child = newChildNode(problem, node, action);
+        // if child.STATE is not in explored or frontier then
+        if (!(explored.contains(child.state()) || containsState(frontier, child.state()))) {
+          // if problem.GOAL-TEST(child.STATE) then return SOLUTION(child)
+          if (isGoalState(child, problem)) {
+            return solution(child);
+          }
+          // frontier <- INSERT(child, frontier)
+          frontier.add(child);
+        }
+      }
+    }
+  }
+
+  /* Supporting code */
+  private NodeFactory<A, S> nodeFactory = new BasicNodeFactory<>();
+  private SearchController<A, S> searchController = new BasicSearchController<>();
+
+  private Node<A, S> newRootNode(S initialState, double pathCost) {
+    return nodeFactory.newRootNode(initialState, pathCost);
+  }
+
+  private Node<A, S> newChildNode(Problem<A, S> problem, Node<A, S> node, A action) {
+    return nodeFactory.newChildNode(problem, node, action);
+  }
+
+  private boolean isGoalState(Node<A, S> node, Problem<A, S> problem) {
+    return searchController.isGoalState(node, problem);
+  }
+
+  private List<A> solution(Node<A, S> node) {
+    return searchController.solution(node);
+  }
+
+  private List<A> failure() {
+    return searchController.failure();
+  }
+
+  private Queue<Node<A,S>> newLIFOQueue(Node<A, S> node) {
+    Queue<Node<A, S>> frontier = Collections.asLifoQueue(new LinkedList<>());
+    frontier.add(node);
+    return frontier;
+  }
+
+  private Set<S> newExploredSet() {
+    return new HashSet<>();
+  }
+
+  private boolean containsState(Queue<Node<A, S>> frontier, S state) {
+    // NOTE: Not very efficient (i.e. linear in the size of the frontier)
+    return frontier.stream().anyMatch(frontierNode -> frontierNode.state().equals(state));
+  }
+}

--- a/core/src/main/java/aima/core/search/basic/uninformed/DepthFirstSearch.java
+++ b/core/src/main/java/aima/core/search/basic/uninformed/DepthFirstSearch.java
@@ -45,40 +45,27 @@ import java.util.Set;
  * expansion.
  */
 public class DepthFirstSearch<A, S> implements SearchForActionsFunction<A, S> {
-  // function DEPTH-FIRST-SEARCH(problem) returns a solution, or failure
+
   @Override
   public List<A> apply(Problem<A, S> problem) {
-    // node <- a node with STATE = problem.INITIAL-STATE, PATH-COST=0
     Node<A, S> node = newRootNode(problem.initialState(), 0);
-    // if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
     if (isGoalState(node, problem)) {
       return solution(node);
     }
-    // frontier <- a LIFO queue with node as the only element
     Queue<Node<A, S>> frontier = newLIFOQueue(node);
-    // explored <- an empty set
     Set<S> explored = newExploredSet();
-    // loop do
     while (true) {
-      // if EMPTY?(frontier) then return failure
       if (frontier.isEmpty()) {
         return failure();
       }
-      // node <- POP(frontier) // chooses the deepest unexplored node in the frontier
       node = frontier.remove();
-      // add node.STATE to explored
       explored.add(node.state());
-      // for each action in problem.ACTIONS(node.STATE) do
       for (A action : problem.actions(node.state())) {
-        // child <- CHILD-NODE(problem, node, action)
         Node<A, S> child = newChildNode(problem, node, action);
-        // if child.STATE is not in explored or frontier then
         if (!(explored.contains(child.state()) || containsState(frontier, child.state()))) {
-          // if problem.GOAL-TEST(child.STATE) then return SOLUTION(child)
           if (isGoalState(child, problem)) {
             return solution(child);
           }
-          // frontier <- INSERT(child, frontier)
           frontier.add(child);
         }
       }

--- a/test/src/test/java/aima/test/unit/search/uninformed/DepthFirstSearchTest.java
+++ b/test/src/test/java/aima/test/unit/search/uninformed/DepthFirstSearchTest.java
@@ -1,0 +1,66 @@
+package aima.test.unit.search.uninformed;
+
+import static aima.core.environment.map2d.SimplifiedRoadMapOfPartOfRomania.*;
+import static org.junit.Assert.assertEquals;
+
+import aima.core.environment.map2d.GoAction;
+import aima.core.environment.support.ProblemFactory;
+import aima.core.search.api.Problem;
+import aima.core.search.api.SearchForActionsFunction;
+import aima.core.search.basic.uninformed.DepthFirstSearch;
+import aima.extra.search.pqueue.uninformed.DepthFirstQueueSearch;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class DepthFirstSearchTest {
+
+  @Parameters(name = "{index}: {0}")
+  public static Collection<Object[]> implementations() {
+    return Arrays.asList(new Object[][]{{"DepthFirstSearch"}, {"DepthFirstQueueSearch"}});
+  }
+
+  @Parameter
+  public String searchFunctionName;
+
+  public <A, S> List<A> searchForActions(Problem<A, S> problem) {
+    SearchForActionsFunction<A, S> searchForActionsFunction;
+    if ("DepthFirstSearch".equals(searchFunctionName)) {
+      searchForActionsFunction = new DepthFirstSearch<>();
+    } else if ("DepthFirstQueueSearch".equals(searchFunctionName)) {
+      searchForActionsFunction = new DepthFirstQueueSearch<>();
+    } else {
+      throw new UnsupportedOperationException(
+          "Unsupported search function name: " + searchFunctionName);
+    }
+    return searchForActionsFunction.apply(problem);
+  }
+
+  @Test
+  public void testSimplifiedRoadmapOfPartOfRomania() {
+    assertEquals(Arrays.asList((GoAction) null),
+        searchForActions(ProblemFactory.getSimplifiedRoadMapOfPartOfRomaniaProblem(ARAD, ARAD)));
+
+    List<GoAction> goal = Arrays
+        .asList(new GoAction(SIBIU), new GoAction(RIMNICU_VILCEA), new GoAction(PITESTI),
+            new GoAction(BUCHAREST));
+    assertEquals(goal, searchForActions(
+        ProblemFactory.getSimplifiedRoadMapOfPartOfRomaniaProblem(ARAD, BUCHAREST)));
+
+    goal = Arrays.asList(new GoAction(SIBIU), new GoAction(RIMNICU_VILCEA), new GoAction(PITESTI),
+        new GoAction(BUCHAREST), new GoAction(URZICENI), new GoAction(VASLUI), new GoAction(IASI),
+        new GoAction(NEAMT));
+    assertEquals(goal,
+        searchForActions(ProblemFactory.getSimplifiedRoadMapOfPartOfRomaniaProblem(ARAD, NEAMT)));
+
+    goal = Arrays.asList(new GoAction(ZERIND));
+    assertEquals(goal, searchForActions(
+        ProblemFactory.getSimplifiedRoadMapOfPartOfRomaniaProblem(ORADEA, ZERIND)));
+  }
+}


### PR DESCRIPTION
The pull request proposes following changes:

1. Add implementation of Depth-First-Search (in core module)
2. Add unit test for both DepthFirstSearch(core) and DepthFirstQueueSearch(extra)
3. Update README.md to indicate core and experimental alternatives to Depth-First-Search implementation. 

@norvig Kindly review this PR.