### PR TITLE
Add ConvertToCNF to readme.md of AIMA4e

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,12 @@ Java implementation of algorithms from Russell and Norvig's "Artificial Intellig
    <tr>
        <td>7.?</td>
        <td>??</td>
+       <td>ConvertToCNF</td>
+       <td><a href="core/src/main/java/aima/core/logic/basic/propositional/visitors/ConvertToCNF.java">ConvertToCNF</a></td>
+   </tr>
+   <tr>
+       <td>7.?</td>
+       <td>??</td>
        <td><a href="https://github.com/aimacode/aima-pseudocode/blob/master/md/PL-Resolution.md">PL-Resolution</a></td>
        <td><a href="core/src/main/java/aima/core/logic/basic/propositional/inference/PLResolution.java">PLResolution</a></td>
    </tr>


### PR DESCRIPTION
ConvertToCNF is [present](https://github.com/aimacode/aima-java/blob/AIMA4e/core/src/main/java/aima/core/logic/basic/propositional/visitors/ConvertToCNF.java) but not mentioned in readme.