### PR TITLE
Update .travis.yml to cache gradle dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,14 @@ language: java
 jdk:
 - oraclejdk8
 script: ./gradlew check --info
+
+sudo: false
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/


### PR DESCRIPTION
@norvig This PR updates the `.travis.yml` to [cache gradle dependencies](https://docs.travis-ci.com/user/languages/java/#Caching). It aims improves CI build speed.