### PR TITLE
In class javadoc, replace <- and &lt;- with &larr;

### DIFF
--- a/aima-core/src/main/java/aima/core/agent/impl/aprog/ModelBasedReflexAgentProgram.java
+++ b/aima-core/src/main/java/aima/core/agent/impl/aprog/ModelBasedReflexAgentProgram.java
@@ -22,9 +22,9 @@ import aima.core.agent.impl.aprog.simplerule.Rule;
  *               rules, a set of condition-action rules
  *               action, the most recent action, initially none
  *               
- *   state  <- UPDATE-STATE(state, action, percept, model)
- *   rule   <- RULE-MATCH(state, rules)
- *   action <- rule.ACTION
+ *   state  &larr; UPDATE-STATE(state, action, percept, model)
+ *   rule   &larr; RULE-MATCH(state, rules)
+ *   action &larr; rule.ACTION
  *   return action
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/agent/impl/aprog/SimpleReflexAgentProgram.java
+++ b/aima-core/src/main/java/aima/core/agent/impl/aprog/SimpleReflexAgentProgram.java
@@ -19,9 +19,9 @@ import aima.core.agent.impl.aprog.simplerule.Rule;
  * function SIMPLE-RELEX-AGENT(percept) returns an action
  *   persistent: rules, a set of condition-action rules
  *   
- *   state  <- INTERPRET-INPUT(percept);
- *   rule   <- RULE-MATCH(state, rules);
- *   action <- rule.ACTION;
+ *   state  &larr; INTERPRET-INPUT(percept);
+ *   rule   &larr; RULE-MATCH(state, rules);
+ *   action &larr; rule.ACTION;
  *   return action
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/agent/impl/aprog/TableDrivenAgentProgram.java
+++ b/aima-core/src/main/java/aima/core/agent/impl/aprog/TableDrivenAgentProgram.java
@@ -20,7 +20,7 @@ import aima.core.util.datastructure.Table;
  *               table, a table of actions, indexed by percept sequences, initially fully specified
  *           
  *   append percept to end of percepts
- *   action <- LOOKUP(percepts, table)
+ *   action &larr; LOOKUP(percepts, table)
  *   return action
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/environment/wumpusworld/EfficientHybridWumpusAgent.java
+++ b/aima-core/src/main/java/aima/core/environment/wumpusworld/EfficientHybridWumpusAgent.java
@@ -28,23 +28,23 @@ import java.util.*;
  *
  *   TELL(KB, MAKE-PERCEPT-SENTENCE(percept, t))
  *   TELL the KB the temporal "physics" sentences for time t
- *   safe <- {[x, y] : ASK(KB, OK<sup>t</sup><sub>x,y</sub>) = true}
+ *   safe &larr; {[x, y] : ASK(KB, OK<sup>t</sup><sub>x,y</sub>) = true}
  *   if ASK(KB, Glitter<sup>t</sup>) = true then
- *      plan <- [Grab] + PLAN-ROUTE(current, {[1,1]}, safe) + [Climb]
+ *      plan &larr; [Grab] + PLAN-ROUTE(current, {[1,1]}, safe) + [Climb]
  *   if plan is empty then
- *      unvisited <- {[x, y] : ASK(KB, L<sup>t'</sup><sub>x,y</sub>) = false for all t' &le; t}
- *      plan <- PLAN-ROUTE(current, unvisited &cap; safe, safe)
+ *      unvisited &larr; {[x, y] : ASK(KB, L<sup>t'</sup><sub>x,y</sub>) = false for all t' &le; t}
+ *      plan &larr; PLAN-ROUTE(current, unvisited &cap; safe, safe)
  *   if plan is empty and ASK(KB, HaveArrow<sup>t</sup>) = true then
- *      possible_wumpus <- {[x, y] : ASK(KB, ~W<sub>x,y</sub>) = false}
- *      plan <- PLAN-SHOT(current, possible_wumpus, safe)
+ *      possible_wumpus &larr; {[x, y] : ASK(KB, ~W<sub>x,y</sub>) = false}
+ *      plan &larr; PLAN-SHOT(current, possible_wumpus, safe)
  *   if plan is empty then //no choice but to take a risk
- *      not_unsafe <- {[x, y] : ASK(KB, ~OK<sup>t</sup><sub>x,y</sub>) = false}
- *      plan <- PLAN-ROUTE(current, unvisited &cap; not_unsafe, safe)
+ *      not_unsafe &larr; {[x, y] : ASK(KB, ~OK<sup>t</sup><sub>x,y</sub>) = false}
+ *      plan &larr; PLAN-ROUTE(current, unvisited &cap; not_unsafe, safe)
  *   if plan is empty then
- *      plan <- PLAN-ROUTE(current, {[1,1]}, safe) + [Climb]
- *   action <- POP(plan)
+ *      plan &larr; PLAN-ROUTE(current, {[1,1]}, safe) + [Climb]
+ *   action &larr; POP(plan)
  *   TELL(KB, MAKE-ACTION-SENTENCE(action, t))
- *   t <- t+1
+ *   t &larr; t+1
  *   return action
  *
  * --------------------------------------------------------------------------------
@@ -54,7 +54,7 @@ import java.util.*;
  *           goals, a set of squares; try to plan a route to one of them
  *           allowed, a set of squares that can form part of the route
  *
- *   problem <- ROUTE-PROBLEM(current, goals, allowed)
+ *   problem &larr; ROUTE-PROBLEM(current, goals, allowed)
  *   return A*-GRAPH-SEARCH(problem)
  * </code>
  * </pre>

--- a/aima-core/src/main/java/aima/core/environment/wumpusworld/HybridWumpusAgent.java
+++ b/aima-core/src/main/java/aima/core/environment/wumpusworld/HybridWumpusAgent.java
@@ -30,23 +30,23 @@ import java.util.*;
  * 
  *   TELL(KB, MAKE-PERCEPT-SENTENCE(percept, t))
  *   TELL the KB the temporal "physics" sentences for time t
- *   safe <- {[x, y] : ASK(KB, OK<sup>t</sup><sub>x,y</sub>) = true}
+ *   safe &larr; {[x, y] : ASK(KB, OK<sup>t</sup><sub>x,y</sub>) = true}
  *   if ASK(KB, Glitter<sup>t</sup>) = true then
- *      plan <- [Grab] + PLAN-ROUTE(current, {[1,1]}, safe) + [Climb]
+ *      plan &larr; [Grab] + PLAN-ROUTE(current, {[1,1]}, safe) + [Climb]
  *   if plan is empty then
- *      unvisited <- {[x, y] : ASK(KB, L<sup>t'</sup><sub>x,y</sub>) = false for all t' &le; t}
- *      plan <- PLAN-ROUTE(current, unvisited &cap; safe, safe)
+ *      unvisited &larr; {[x, y] : ASK(KB, L<sup>t'</sup><sub>x,y</sub>) = false for all t' &le; t}
+ *      plan &larr; PLAN-ROUTE(current, unvisited &cap; safe, safe)
  *   if plan is empty and ASK(KB, HaveArrow<sup>t</sup>) = true then
- *      possible_wumpus <- {[x, y] : ASK(KB, ~W<sub>x,y</sub>) = false}
- *      plan <- PLAN-SHOT(current, possible_wumpus, safe)
+ *      possible_wumpus &larr; {[x, y] : ASK(KB, ~W<sub>x,y</sub>) = false}
+ *      plan &larr; PLAN-SHOT(current, possible_wumpus, safe)
  *   if plan is empty then //no choice but to take a risk
- *      not_unsafe <- {[x, y] : ASK(KB, ~OK<sup>t</sup><sub>x,y</sub>) = false}
- *      plan <- PLAN-ROUTE(current, unvisited &cap; not_unsafe, safe)
+ *      not_unsafe &larr; {[x, y] : ASK(KB, ~OK<sup>t</sup><sub>x,y</sub>) = false}
+ *      plan &larr; PLAN-ROUTE(current, unvisited &cap; not_unsafe, safe)
  *   if plan is empty then
- *      plan <- PLAN-ROUTE(current, {[1,1]}, safe) + [Climb]
- *   action <- POP(plan)
+ *      plan &larr; PLAN-ROUTE(current, {[1,1]}, safe) + [Climb]
+ *   action &larr; POP(plan)
  *   TELL(KB, MAKE-ACTION-SENTENCE(action, t))
- *   t <- t+1
+ *   t &larr; t+1
  *   return action
  * 
  * --------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ import java.util.*;
  *           goals, a set of squares; try to plan a route to one of them
  *           allowed, a set of squares that can form part of the route 
  *    
- *   problem <- ROUTE-PROBLEM(current, goals, allowed)
+ *   problem &larr; ROUTE-PROBLEM(current, goals, allowed)
  *   return A*-GRAPH-SEARCH(problem)
  * </code>
  * </pre>

--- a/aima-core/src/main/java/aima/core/learning/knowledge/CurrentBestLearning.java
+++ b/aima-core/src/main/java/aima/core/learning/knowledge/CurrentBestLearning.java
@@ -14,16 +14,16 @@ import aima.core.logic.fol.kb.FOLKnowledgeBase;
  * 
  *   if examples is empty then
  *      return h
- *   e <- FIRST(examples)
+ *   e &larr; FIRST(examples)
  *   if e is consistent with h then
  *      return CURRENT-BEST-LEARNING(REST(examples), h)
  *   else if e is a false positive for h then
  *     for each h' in specializations of h consistent with examples seen so far do
- *       h'' <- CURRENT-BEST-LEARNING(REST(examples), h')
+ *       h'' &larr; CURRENT-BEST-LEARNING(REST(examples), h')
  *       if h'' != fail then return h''
  *   else if e is a false negative for h then
  *     for each h' in generalization of h consistent with examples seen so far do
- *       h'' <- CURRENT-BEST-LEARNING(REST(examples), h')
+ *       h'' &larr; CURRENT-BEST-LEARNING(REST(examples), h')
  *       if h'' != fail then return h''
  *   return fail
  * </pre>

--- a/aima-core/src/main/java/aima/core/learning/reinforcement/agent/PassiveADPAgent.java
+++ b/aima-core/src/main/java/aima/core/learning/reinforcement/agent/PassiveADPAgent.java
@@ -29,13 +29,13 @@ import aima.core.util.datastructure.Pair;
  *               N<sub>s'|sa</sub>, a table of outcome frequencies give state-action pairs, initially zero
  *               s, a, the previous state and action, initially null
  *
- *   if s' is new then U[s'] <- r'; R[s'] <- r'
+ *   if s' is new then U[s'] &larr; r'; R[s'] &larr; r'
  *   if s is not null then
  *        increment N<sub>sa</sub>[s,a] and N<sub>s'|sa</sub>[s',s,a]
  *        for each t such that N<sub>s'|sa</sub>[t,s,a] is nonzero do
- *            P(t|s,a) <-  N<sub>s'|sa</sub>[t,s,a] / N<sub>sa</sub>[s,a]
- *   U <- POLICY-EVALUATION(&pi;, U, mdp)
- *   if s'.TERMINAL? then s,a <- null else s,a <- s',&pi;[s']
+ *            P(t|s,a) &larr;  N<sub>s'|sa</sub>[t,s,a] / N<sub>sa</sub>[s,a]
+ *   U &larr; POLICY-EVALUATION(&pi;, U, mdp)
+ *   if s'.TERMINAL? then s,a &larr; null else s,a &larr; s',&pi;[s']
  *   return a
  * </pre>
  *

--- a/aima-core/src/main/java/aima/core/learning/reinforcement/agent/PassiveTDAgent.java
+++ b/aima-core/src/main/java/aima/core/learning/reinforcement/agent/PassiveTDAgent.java
@@ -19,11 +19,11 @@ import aima.core.util.FrequencyCounter;
  *               N<sub>s</sub>, a table of frequencies for states, initially zero
  *               s,a,r, the previous state, action, and reward, initially null
  *               
- *   if s' is new then U[s'] <- r'
+ *   if s' is new then U[s'] &larr; r'
  *   if s is not null then
  *        increment N<sub>s</sub>[s]
- *        U[s] <- U[s] + &alpha;(N<sub>s</sub>[s])(r + &gamma;U[s'] - U[s])
- *   if s'.TERMINAL? then s,a,r <- null else s,a,r <- s',&pi;[s'],r'
+ *        U[s] &larr; U[s] + &alpha;(N<sub>s</sub>[s])(r + &gamma;U[s'] - U[s])
+ *   if s'.TERMINAL? then s,a,r &larr; null else s,a,r &larr; s',&pi;[s'],r'
  *   return a
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/learning/reinforcement/agent/QLearningAgent.java
+++ b/aima-core/src/main/java/aima/core/learning/reinforcement/agent/QLearningAgent.java
@@ -20,11 +20,11 @@ import aima.core.util.datastructure.Pair;
  *               N<sub>sa</sub>, a table of frequencies for state-action pairs, initially zero
  *               s,a,r, the previous state, action, and reward, initially null
  *               
- *   if TERMAINAL?(s) then Q[s,None] <- r'
+ *   if TERMAINAL?(s) then Q[s,None] &larr; r'
  *   if s is not null then
  *       increment N<sub>sa</sub>[s,a]
- *       Q[s,a] <- Q[s,a] + &alpha;(N<sub>sa</sub>[s,a])(r + &gamma;max<sub>a'</sub>Q[s',a'] - Q[s,a])
- *   s,a,r <- s',argmax<sub>a'</sub>f(Q[s',a'],N<sub>sa</sub>[s',a']),r'
+ *       Q[s,a] &larr; Q[s,a] + &alpha;(N<sub>sa</sub>[s,a])(r + &gamma;max<sub>a'</sub>Q[s',a'] - Q[s,a])
+ *   s,a,r &larr; s',argmax<sub>a'</sub>f(Q[s',a'],N<sub>sa</sub>[s',a']),r'
  *   return a
  * </pre>
  * 
@@ -36,17 +36,17 @@ import aima.core.util.datastructure.Pair;
  * <br>
  * <b>Note:</b> There appears to be two minor defects in the algorithm outlined
  * in the book:<br>
- * if TERMAINAL?(s) then Q[s,None] <- r'<br>
+ * if TERMAINAL?(s) then Q[s,None] &larr; r'<br>
  * should be:<br>
- * if TERMAINAL?(s') then Q[s',None] <- r'<br>
+ * if TERMAINAL?(s') then Q[s',None] &larr; r'<br>
  * so that the correct value for Q[s',a'] is used in the Q[s,a] update rule when
  * a terminal state is reached.<br>
  * <br>
- * s,a,r <- s',argmax<sub>a'</sub>f(Q[s',a'],N<sub>sa</sub>[s',a']),r'<br>
+ * s,a,r &larr; s',argmax<sub>a'</sub>f(Q[s',a'],N<sub>sa</sub>[s',a']),r'<br>
  * should be:
  * 
  * <pre>
- * if s'.TERMINAL? then s,a,r <- null else s,a,r <- s',argmax<sub>a'</sub>f(Q[s',a'],N<sub>sa</sub>[s',a']),r'
+ * if s'.TERMINAL? then s,a,r &larr; null else s,a,r &larr; s',argmax<sub>a'</sub>f(Q[s',a'],N<sub>sa</sub>[s',a']),r'
  * </pre>
  * 
  * otherwise at the beginning of a consecutive trial, s will be the prior

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/FOLBCAsk.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/FOLBCAsk.java
@@ -29,11 +29,11 @@ import aima.core.logic.fol.parsing.ast.Variable;
  *   local variables: answers, a set of substitutions, initially empty
  *   
  *   if goals is empty then return {theta}
- *   qDelta &lt;- SUBST(theta, FIRST(goals))
+ *   qDelta &larr; SUBST(theta, FIRST(goals))
  *   for each sentence r in KB where STANDARDIZE-APART(r) = (p1 &circ; ... &circ; pn =&gt; q)
- *          and thetaDelta &lt;- UNIFY(q, qDelta) succeeds
- *       new_goals &lt;- [p1,...,pn|REST(goals)]
- *       answers &lt;- FOL-BC-ASK(KB, new_goals, COMPOSE(thetaDelta, theta)) U answers
+ *          and thetaDelta &larr; UNIFY(q, qDelta) succeeds
+ *       new_goals &larr; [p1,...,pn|REST(goals)]
+ *       answers &larr; FOL-BC-ASK(KB, new_goals, COMPOSE(thetaDelta, theta)) U answers
  *   return answers
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/FOLFCAsk.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/FOLFCAsk.java
@@ -31,15 +31,15 @@ import aima.core.logic.fol.parsing.ast.Variable;
  *   local variables: new, the new sentences inferred on each iteration
  *   
  *   repeat until new is empty
- *      new &lt;- {}
+ *      new &larr; {}
  *      for each rule in KB do
- *          (p1 &circ; ... &circ; pn =&gt; q) &lt;- STANDARDIZE-VARAIBLES(rule)
+ *          (p1 &circ; ... &circ; pn =&gt; q) &larr; STANDARDIZE-VARAIBLES(rule)
  *          for each theta such that SUBST(theta, p1 &circ; ... &circ; pn) = SUBST(theta, p'1 &circ; ... &circ; p'n)
  *                         for some p'1,...,p'n in KB
- *              q' &lt;- SUBST(theta, q)
+ *              q' &larr; SUBST(theta, q)
  *              if q' does not unify with some sentence already in KB or new then
  *                   add q' to new
- *                   theta &lt;- UNIFY(q', alpha)
+ *                   theta &larr; UNIFY(q', alpha)
  *                   if theta is not fail then return theta
  *      add new to KB
  *   return false

--- a/aima-core/src/main/java/aima/core/logic/fol/inference/FOLOTTERLikeTheoremProver.java
+++ b/aima-core/src/main/java/aima/core/logic/fol/inference/FOLOTTERLikeTheoremProver.java
@@ -40,7 +40,7 @@ import aima.core.logic.fol.parsing.ast.Variable;
  *   usable, background knowledge potentially relevant to the problem
  *   
  *   repeat
- *      clause <- the lightest member of sos
+ *      clause &larr; the lightest member of sos
  *      move clause from sos to usable
  *      PROCESS(INFER(clause, usable), sos)
  *   until sos = [] or a refutation has been found
@@ -57,10 +57,10 @@ import aima.core.logic.fol.parsing.ast.Variable;
  * procedure PROCESS(clauses, sos)
  * 
  *   for each clause in clauses do
- *       clause <- SIMPLIFY(clause)
+ *       clause &larr; SIMPLIFY(clause)
  *       merge identical literals
  *       discard clause if it is a tautology
- *       sos <- [clause | sos]
+ *       sos &larr; [clause | sos]
  *       if clause has no literals then a refutation has been found
  *       if clause has one literal then look for unit refutation
  * </pre>

--- a/aima-core/src/main/java/aima/core/logic/propositional/agent/KBAgent.java
+++ b/aima-core/src/main/java/aima/core/logic/propositional/agent/KBAgent.java
@@ -17,9 +17,9 @@ import aima.core.logic.propositional.parsing.ast.Sentence;
  *               t, a counter, initially 0, indicating time
  *           
  *   TELL(KB, MAKE-PERCEPT-SENTENCE(percept, t))
- *   action &lt;- ASK(KB, MAKE-ACTION-QUERY(t))
+ *   action &larr; ASK(KB, MAKE-ACTION-QUERY(t))
  *   TELL(KB, MAKE-ACTION-SENTENCE(action, t))
- *   t &lt;- t + 1
+ *   t &larr; t + 1
  *   return action
  * 
  * </pre>

--- a/aima-core/src/main/java/aima/core/logic/propositional/inference/TTEntails.java
+++ b/aima-core/src/main/java/aima/core/logic/propositional/inference/TTEntails.java
@@ -20,7 +20,7 @@ import aima.core.util.Util;
  *   inputs: KB, the knowledge base, a sentence in propositional logic
  *           &alpha;, the query, a sentence in propositional logic
  *           
- *   symbols <- a list of proposition symbols in KB and &alpha
+ *   symbols &larr; a list of proposition symbols in KB and &alpha
  *   return TT-CHECK-ALL(KB, &alpha; symbols, {})
  *   
  * --------------------------------------------------------------------------------
@@ -30,8 +30,8 @@ import aima.core.util.Util;
  *     if PL-TRUE?(KB, model) then return PL-TRUE?(&alpha;, model)
  *     else return true // when KB is false, always return true
  *   else do
- *     P <- FIRST(symbols)
- *     rest <- REST(symbols)
+ *     P &larr; FIRST(symbols)
+ *     rest &larr; REST(symbols)
  *     return (TT-CHECK-ALL(KB, &alpha;, rest, model &cup; { P = true })
  *            and
  *            TT-CHECK-ALL(KB, &alpha;, rest, model &cup; { P = false }))

--- a/aima-core/src/main/java/aima/core/logic/propositional/inference/WalkSAT.java
+++ b/aima-core/src/main/java/aima/core/logic/propositional/inference/WalkSAT.java
@@ -23,10 +23,10 @@ import aima.core.logic.propositional.parsing.ast.PropositionSymbol;
  *           p, the probability of choosing to do a "random walk" move, typically around 0.5
  *           max_flips, number of flips allowed before giving up
  *           
- *   model <- a random assignment of true/false to the symbols in clauses
+ *   model &larr; a random assignment of true/false to the symbols in clauses
  *   for i = 1 to max_flips do
  *       if model satisfies clauses then return model
- *       clause <- a randomly selected clause from clauses that is false in model
+ *       clause &larr; a randomly selected clause from clauses that is false in model
  *       with probability p flip the value in model of a randomly selected symbol from clause
  *       else flip whichever symbol in clause maximizes the number of satisfied clauses
  *   return failure

--- a/aima-core/src/main/java/aima/core/nlp/parsing/CYK.java
+++ b/aima-core/src/main/java/aima/core/nlp/parsing/CYK.java
@@ -13,20 +13,20 @@ import aima.core.nlp.parsing.grammars.Rule;
  * 
  * <pre>
  * function CYK-PARSE(words, grammar) returns P, a table of probabilities
- *   N <- LENGTH(words)
- *   M <- the number of nonterminal symbols in grammar
- *   P <- an array of size[M,N,N], initially all 0
+ *   N &larr; LENGTH(words)
+ *   M &larr; the number of nonterminal symbols in grammar
+ *   P &larr; an array of size[M,N,N], initially all 0
  *   /* Insert Lexical rules for each word *\
  *   for i = 1 to N do
  *   	for each rule of form( X -> words<sub>i</sub>[p]) do
- *   		P[X,i,1] <- p
+ *   		P[X,i,1] &larr; p
  *   /* Combine first and second parts of right-hand sides of rules, from short to long *\
  *   for length = 2 to N do
  *   	for start = 1 to N - length + 1 do
  *   		for len1 = 1 to N -1 do 
- *   			len2 <- length - len1
+ *   			len2 &larr; length - len1
  *   		for each rule of the form( X -> Y Z [p] ) do
- *   			p[X, start, length] <- MAX(P[X, start, length],
+ *   			p[X, start, length] &larr; MAX(P[X, start, length],
  *   						P[Y, start, len1] * P[Z, start + len1, len2] * p)
  *   return P
  * </pre>

--- a/aima-core/src/main/java/aima/core/probability/bayes/approx/GibbsAsk.java
+++ b/aima-core/src/main/java/aima/core/probability/bayes/approx/GibbsAsk.java
@@ -29,7 +29,7 @@ import aima.core.util.Randomizer;
  *   for j = 1 to N do
  *       for each Z<sub>i</sub> in Z do
  *           set the value of Z<sub>i</sub> in <b>x</b> by sampling from <b>P</b>(Z<sub>i</sub>|mb(Z<sub>i</sub>))
- *           <b>N</b>[x] <- <b>N</b>[x] + 1 where x is the value of X in <b>x</b>
+ *           <b>N</b>[x] &larr; <b>N</b>[x] + 1 where x is the value of X in <b>x</b>
  *   return NORMALIZE(<b>N</b>)
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/probability/bayes/approx/LikelihoodWeighting.java
+++ b/aima-core/src/main/java/aima/core/probability/bayes/approx/LikelihoodWeighting.java
@@ -27,17 +27,17 @@ import aima.core.util.datastructure.Pair;
  *   local variables: W, a vector of weighted counts for each value of X, initially zero
  *   
  *   for j = 1 to N do
- *       <b>x</b>,w <- WEIGHTED-SAMPLE(bn,e)
- *       W[x] <- W[x] + w where x is the value of X in <b>x</b>
+ *       <b>x</b>,w &larr; WEIGHTED-SAMPLE(bn,e)
+ *       W[x] &larr; W[x] + w where x is the value of X in <b>x</b>
  *   return NORMALIZE(W)
  * --------------------------------------------------------------------------------------
  * function WEIGHTED-SAMPLE(bn, e) returns an event and a weight
  *   
- *    w <- 1; <b>x</b> <- an event with n elements initialized from e
+ *    w &larr; 1; <b>x</b> &larr; an event with n elements initialized from e
  *    foreach variable X<sub>i</sub> in X<sub>1</sub>,...,X<sub>n</sub> do
  *        if X<sub>i</sub> is an evidence variable with value x<sub>i</sub> in e
- *            then w <- w * P(X<sub>i</sub> = x<sub>i</sub> | parents(X<sub>i</sub>))
- *            else <b>x</b>[i] <- a random sample from <b>P</b>(X<sub>i</sub> | parents(X<sub>i</sub>))
+ *            then w &larr; w * P(X<sub>i</sub> = x<sub>i</sub> | parents(X<sub>i</sub>))
+ *            else <b>x</b>[i] &larr; a random sample from <b>P</b>(X<sub>i</sub> | parents(X<sub>i</sub>))
  *    return <b>x</b>, w
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/probability/bayes/approx/ParticleFiltering.java
+++ b/aima-core/src/main/java/aima/core/probability/bayes/approx/ParticleFiltering.java
@@ -29,9 +29,9 @@ import aima.core.util.Util;
  *   local variables: W, a vector of weights of size N
  *   
  *   for i = 1 to N do
- *       S[i] <- sample from <b>P</b>(<b>X</b><sub>1</sub> | <b>X</b><sub>0</sub> = S[i]) /* step 1 
- *       W[i] <- <b>P</b>(<b>e</b> | <b>X</b><sub>1</sub> = S[i]) /* step 2
- *   S <- WEIGHTED-SAMPLE-WITH-REPLACEMENT(N, S, W) /* step 3
+ *       S[i] &larr; sample from <b>P</b>(<b>X</b><sub>1</sub> | <b>X</b><sub>0</sub> = S[i]) /* step 1 
+ *       W[i] &larr; <b>P</b>(<b>e</b> | <b>X</b><sub>1</sub> = S[i]) /* step 2
+ *   S &larr; WEIGHTED-SAMPLE-WITH-REPLACEMENT(N, S, W) /* step 3
  *   return S
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/probability/bayes/approx/PriorSample.java
+++ b/aima-core/src/main/java/aima/core/probability/bayes/approx/PriorSample.java
@@ -18,9 +18,9 @@ import aima.core.util.Randomizer;
  * function PRIOR-SAMPLE(bn) returns an event sampled from the prior specified by bn
  *   inputs: bn, a Bayesian network specifying joint distribution <b>P</b>(X<sub>1</sub>,...,X<sub>n</sub>)
  * 
- *   x <- an event with n elements
+ *   x &larr; an event with n elements
  *   foreach variable X<sub>i</sub> in X<sub>1</sub>,...,X<sub>n</sub> do
- *      x[i] <- a random sample from <b>P</b>(X<sub>i</sub> | parents(X<sub>i</sub>))
+ *      x[i] &larr; a random sample from <b>P</b>(X<sub>i</sub> | parents(X<sub>i</sub>))
  *   return x
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/probability/bayes/approx/RejectionSampling.java
+++ b/aima-core/src/main/java/aima/core/probability/bayes/approx/RejectionSampling.java
@@ -22,9 +22,9 @@ import aima.core.probability.util.ProbabilityTable;
  *   local variables: <b>N</b>, a vector of counts for each value of X, initially zero
  *   
  *   for j = 1 to N do
- *       <b>x</b> <- PRIOR-SAMPLE(bn)
+ *       <b>x</b> &larr; PRIOR-SAMPLE(bn)
  *       if <b>x</b> is consistent with e then
- *          <b>N</b>[x] <- <b>N</b>[x] + 1 where x is the value of X in <b>x</b>
+ *          <b>N</b>[x] &larr; <b>N</b>[x] + 1 where x is the value of X in <b>x</b>
  *   return NORMALIZE(<b>N</b>)
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/probability/bayes/exact/EliminationAsk.java
+++ b/aima-core/src/main/java/aima/core/probability/bayes/exact/EliminationAsk.java
@@ -28,10 +28,10 @@ import aima.core.probability.util.ProbabilityTable;
  *           e, observed values for variables E
  *           bn, a Bayesian network specifying joint distribution P(X<sub>1</sub>, ..., X<sub>n</sub>)
  *   
- *   factors <- []
+ *   factors &larr; []
  *   for each var in ORDER(bn.VARS) do
- *       factors <- [MAKE-FACTOR(var, e) | factors]
- *       if var is hidden variable the factors <- SUM-OUT(var, factors)
+ *       factors &larr; [MAKE-FACTOR(var, e) | factors]
+ *       if var is hidden variable the factors &larr; SUM-OUT(var, factors)
  *   return NORMALIZE(POINTWISE-PRODUCT(factors))
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/probability/bayes/exact/EnumerationAsk.java
+++ b/aima-core/src/main/java/aima/core/probability/bayes/exact/EnumerationAsk.java
@@ -26,9 +26,9 @@ import aima.core.util.Util;
  *           e, observed values for variables E
  *           bn, a Bayes net with variables {X} &cup; E &cup; Y /* Y = hidden variables //
  *           
- *   Q(X) <- a distribution over X, initially empty
+ *   Q(X) &larr; a distribution over X, initially empty
  *   for each value x<sub>i</sub> of X do
- *       Q(x<sub>i</sub>) <- ENUMERATE-ALL(bn.VARS, e<sub>x<sub>i</sub></sub>)
+ *       Q(x<sub>i</sub>) &larr; ENUMERATE-ALL(bn.VARS, e<sub>x<sub>i</sub></sub>)
  *          where e<sub>x<sub>i</sub></sub> is e extended with X = x<sub>i</sub>
  *   return NORMALIZE(Q(X))
  *   
@@ -36,7 +36,7 @@ import aima.core.util.Util;
  * 
  * function ENUMERATE-ALL(vars, e) returns a real number
  *   if EMPTY?(vars) then return 1.0
- *   Y <- FIRST(vars)
+ *   Y &larr; FIRST(vars)
  *   if Y has value y in e
  *       then return P(y | parents(Y)) * ENUMERATE-ALL(REST(vars), e)
  *       else return &sum;<sub>y</sub> P(y | parents(Y)) * ENUMERATE-ALL(REST(vars), e<sub>y</sub>)

--- a/aima-core/src/main/java/aima/core/probability/hmm/exact/FixedLagSmoothing.java
+++ b/aima-core/src/main/java/aima/core/probability/hmm/exact/FixedLagSmoothing.java
@@ -24,14 +24,14 @@ import aima.core.util.math.Matrix;
  *   local variables: <b>O</b><sub>t-d</sub>, <b>O</b><sub>t</sub>, diagonal matrices containing the sensor model information
  *   
  *   add e<sub>t</sub> to the end of e<sub>t-d:t</sub>
- *   <b>O</b><sub>t</sub> <- diagonal matrix containing <b>P</b>(e<sub>t</sub> | X<sub>t</sub>)
+ *   <b>O</b><sub>t</sub> &larr; diagonal matrix containing <b>P</b>(e<sub>t</sub> | X<sub>t</sub>)
  *   if t > d then
- *        <b>f</b> <- FORWARD(<b>f</b>, e<sub>t</sub>)
+ *        <b>f</b> &larr; FORWARD(<b>f</b>, e<sub>t</sub>)
  *        remove e<sub>t-d-1</sub> from the beginning of e<sub>t-d:t</sub>
- *        <b>O</b><sub>t-d</sub> <- diagonal matrix containing <b>P</b>(e<sub>t-d</sub> | X<sub>t-d</sub>)
- *        <b>B</b> <- <b>O</b><sup>-1</sup><sub>t-d</sub><b>B</b><b>T</b><b>O</b><sub>t</sub>
- *   else <b>B</b> <- <b>BTO</b><sub>t</sub>
- *   t <- t + 1
+ *        <b>O</b><sub>t-d</sub> &larr; diagonal matrix containing <b>P</b>(e<sub>t-d</sub> | X<sub>t-d</sub>)
+ *        <b>B</b> &larr; <b>O</b><sup>-1</sup><sub>t-d</sub><b>B</b><b>T</b><b>O</b><sub>t</sub>
+ *   else <b>B</b> &larr; <b>BTO</b><sub>t</sub>
+ *   t &larr; t + 1
  *   if t > d then return NORMALIZE(<b>f</b> * <b>B1</b>) else return null
  * </pre>
  * 
@@ -43,13 +43,13 @@ import aima.core.util.math.Matrix;
  * <br>
  * <b>Note:</b> There appears to be two minor defects in the algorithm outlined
  * in the book:<br>
- * <b>f</b> <- FORWARD(<b>f</b>, e<sub>t</sub>)<br>
+ * <b>f</b> &larr; FORWARD(<b>f</b>, e<sub>t</sub>)<br>
  * should be:<br>
- * <b>f</b> <- FORWARD(<b>f</b>, e<sub>t-d</sub>)<br>
+ * <b>f</b> &larr; FORWARD(<b>f</b>, e<sub>t-d</sub>)<br>
  * as we are returning a smoothed step for t-d and not the current time t. <br>
  * <br>
  * The update of:<br>
- * t <- t + 1<br>
+ * t &larr; t + 1<br>
  * should occur after the return value is calculated. Otherwise when t == d the
  * value returned is based on HMM.prior in the calculation as opposed to a
  * correctly calculated forward message. Comments welcome.

--- a/aima-core/src/main/java/aima/core/probability/hmm/exact/HMMForwardBackward.java
+++ b/aima-core/src/main/java/aima/core/probability/hmm/exact/HMMForwardBackward.java
@@ -21,12 +21,12 @@ import aima.core.util.math.Matrix;
  *                    b, a representation of the backward message, initially all 1s
  *                    sv, a vector of smoothed estimates for steps 1,...,t
  *                    
- *   fv[0] <- prior
+ *   fv[0] &larr; prior
  *   for i = 1 to t do
- *       fv[i] <- FORWARD(fv[i-1], ev[i])
+ *       fv[i] &larr; FORWARD(fv[i-1], ev[i])
  *   for i = t downto 1 do
- *       sv[i] <- NORMALIZE(fv[i] * b)
- *       b <- BACKWARD(b, ev[i])
+ *       sv[i] &larr; NORMALIZE(fv[i] * b)
+ *       b &larr; BACKWARD(b, ev[i])
  *   return sv
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/probability/mdp/impl/ModifiedPolicyEvaluation.java
+++ b/aima-core/src/main/java/aima/core/probability/mdp/impl/ModifiedPolicyEvaluation.java
@@ -20,7 +20,7 @@ import aima.core.probability.mdp.PolicyEvaluation;
  * <br>
  * 
  * <pre>
- * U<sub>i+1</sub>(s) <- R(s) + &gamma;&Sigma;<sub>s'</sub>P(s'|s,&pi;<sub>i</sub>(s))U<sub>i</sub>(s')
+ * U<sub>i+1</sub>(s) &larr; R(s) + &gamma;&Sigma;<sub>s'</sub>P(s'|s,&pi;<sub>i</sub>(s))U<sub>i</sub>(s')
  * </pre>
  * 
  * and this is repeated k times to produce the next utility estimate. The

--- a/aima-core/src/main/java/aima/core/probability/mdp/search/PolicyIteration.java
+++ b/aima-core/src/main/java/aima/core/probability/mdp/search/PolicyIteration.java
@@ -23,12 +23,12 @@ import aima.core.util.Util;
  *                    &pi;, a policy vector indexed by state, initially random
  *                    
  *   repeat
- *      U <- POLICY-EVALUATION(&pi;, U, mdp)
- *      unchanged? <- true
+ *      U &larr; POLICY-EVALUATION(&pi;, U, mdp)
+ *      unchanged? &larr; true
  *      for each state s in S do
  *          if max<sub>a &isin; A(s)</sub> &Sigma;<sub>s'</sub>P(s'|s,a)U[s'] > &Sigma;<sub>s'</sub>P(s'|s,&pi;[s])U[s'] then do
- *             &pi;[s] <- argmax<sub>a &isin; A(s)</sub> &Sigma;<sub>s'</sub>P(s'|s,a)U[s']
- *             unchanged? <- false
+ *             &pi;[s] &larr; argmax<sub>a &isin; A(s)</sub> &Sigma;<sub>s'</sub>P(s'|s,a)U[s']
+ *             unchanged? &larr; false
  *   until unchanged?
  *   return &pi;
  * </pre>

--- a/aima-core/src/main/java/aima/core/probability/mdp/search/ValueIteration.java
+++ b/aima-core/src/main/java/aima/core/probability/mdp/search/ValueIteration.java
@@ -20,10 +20,10 @@ import aima.core.util.Util;
  *                    &delta; the maximum change in the utility of any state in an iteration
  *                    
  *   repeat
- *       U <- U'; &delta; <- 0
+ *       U &larr; U'; &delta; &larr; 0
  *       for each state s in S do
- *           U'[s] <- R(s) + &gamma;  max<sub>a &isin; A(s)</sub> &Sigma;<sub>s'</sub>P(s' | s, a) U[s']
- *           if |U'[s] - U[s]| > &delta; then &delta; <- |U'[s] - U[s]|
+ *           U'[s] &larr; R(s) + &gamma;  max<sub>a &isin; A(s)</sub> &Sigma;<sub>s'</sub>P(s' | s, a) U[s']
+ *           if |U'[s] - U[s]| > &delta; then &delta; &larr; |U'[s] - U[s]|
  *   until &delta; < &epsilon;(1 - &gamma;)/&gamma;
  *   return U
  * </pre>

--- a/aima-core/src/main/java/aima/core/probability/temporal/generic/ForwardBackward.java
+++ b/aima-core/src/main/java/aima/core/probability/temporal/generic/ForwardBackward.java
@@ -27,12 +27,12 @@ import aima.core.probability.util.RandVar;
  *                    b, a representation of the backward message, initially all 1s
  *                    sv, a vector of smoothed estimates for steps 1,...,t
  *                    
- *   fv[0] <- prior
+ *   fv[0] &larr; prior
  *   for i = 1 to t do
- *       fv[i] <- FORWARD(fv[i-1], ev[i])
+ *       fv[i] &larr; FORWARD(fv[i-1], ev[i])
  *   for i = t downto 1 do
- *       sv[i] <- NORMALIZE(fv[i] * b)
- *       b <- BACKWARD(b, ev[i])
+ *       sv[i] &larr; NORMALIZE(fv[i] * b)
+ *       b &larr; BACKWARD(b, ev[i])
  *   return sv
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/search/agent/ProblemSolvingAgent.java
+++ b/aima-core/src/main/java/aima/core/search/agent/ProblemSolvingAgent.java
@@ -27,18 +27,18 @@ import java.util.Queue;
  *   inputs: percept, a percept
  *   static: state, some description of current agent and world state
  *           
- *   state <- UPDATE-STATE(state, percept)
+ *   state &larr; UPDATE-STATE(state, percept)
  *   while (state.plan is empty) do
- *     goal <- FORMULATE-GOAL(state)
+ *     goal &larr; FORMULATE-GOAL(state)
  *     if (goal != null) then
- *       problem    <- FORMULATE-PROBLEM(state, goal)
- *       state.plan <- SEARCH(problem)
+ *       problem    &larr; FORMULATE-PROBLEM(state, goal)
+ *       state.plan &larr; SEARCH(problem)
  *       if (state.plan is empty and !tryWithAnotherGoal()) then
  *         add NO_OP to plan         // failure
  *     else
  *       add NO_OP to plan           // success
- *   action <- FIRST(state.plan)
- *   plan <- REST(state.plan)
+ *   action &larr; FIRST(state.plan)
+ *   plan &larr; REST(state.plan)
  *   return action
  * </code>
  * </pre>

--- a/aima-core/src/main/java/aima/core/search/agent/SimpleProblemSolvingAgent.java
+++ b/aima-core/src/main/java/aima/core/search/agent/SimpleProblemSolvingAgent.java
@@ -22,14 +22,14 @@ import java.util.Queue;
  *               goal, a goal, initially null
  *               problem, a problem formulation
  *           
- *   state &lt;- UPDATE-STATE(state, percept)
+ *   state &larr; UPDATE-STATE(state, percept)
  *   if seq is empty then
- *     goal    &lt;- FORMULATE-GOAL(state)
- *     problem &lt;- FORMULATE-PROBLEM(state, goal)
- *     seq     &lt;- SEARCH(problem)
+ *     goal    &larr; FORMULATE-GOAL(state)
+ *     problem &larr; FORMULATE-PROBLEM(state, goal)
+ *     seq     &larr; SEARCH(problem)
  *     if seq = failure then return a null action
- *   action &lt;- FIRST(seq)
- *   seq &lt;- REST(seq)
+ *   action &larr; FIRST(seq)
+ *   seq &larr; REST(seq)
  *   return action
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/search/framework/problem/BidirectionalProblem.java
+++ b/aima-core/src/main/java/aima/core/search/framework/problem/BidirectionalProblem.java
@@ -2,7 +2,7 @@ package aima.core.search.framework.problem;
 
 /**
  * An interface describing a problem that can be tackled from both directions at
- * once (i.e InitialState<->Goal).
+ * once (i.e InitialState&harr;Goal).
  *
  * @param <S> The type used to represent states
  * @param <A> The type of the actions to be used to navigate through the state space

--- a/aima-core/src/main/java/aima/core/search/informed/RecursiveBestFirstSearch.java
+++ b/aima-core/src/main/java/aima/core/search/informed/RecursiveBestFirstSearch.java
@@ -22,17 +22,17 @@ import java.util.stream.Collectors;
  *
  * function RBFS(problem, node, f_limit) returns a solution, or failure and a new f-cost limit
  *   if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
- *   successors &lt;- []
+ *   successors &larr; []
  *   for each action in problem.ACTION(node.STATE) do
  *       add CHILD-NODE(problem, node, action) into successors
  *   if successors is empty then return failure, infinity
  *   for each s in successors do // update f with value from previous search, if any
- *     s.f &lt;- max(s.g + s.h, node.f)
+ *     s.f &larr; max(s.g + s.h, node.f)
  *   repeat
- *     best &lt;- the lowest f-value node in successors
+ *     best &larr; the lowest f-value node in successors
  *     if best.f &gt; f_limit then return failure, best.f
- *     alternative &lt;- the second-lowest f-value among successors
- *     result, best.f &lt;- RBFS(problem, best, min(f_limit, alternative))
+ *     alternative &larr; the second-lowest f-value among successors
+ *     result, best.f &larr; RBFS(problem, best, min(f_limit, alternative))
  *     if result != failure then return result
  * </pre>
  * <p>

--- a/aima-core/src/main/java/aima/core/search/local/GeneticAlgorithm.java
+++ b/aima-core/src/main/java/aima/core/search/local/GeneticAlgorithm.java
@@ -21,21 +21,21 @@ import java.util.Random;
  *           FITNESS-FN, a function that measures the fitness of an individual
  *           
  *   repeat
- *     new_population &lt;- empty set
+ *     new_population &larr; empty set
  *     for i = 1 to SIZE(population) do
- *       x &lt;- RANDOM-SELECTION(population, FITNESS-FN)
- *       y &lt;- RANDOM-SELECTION(population, FITNESS-FN)
- *       child &lt;- REPRODUCE(x, y)
- *       if (small random probability) then child &lt;- MUTATE(child)
+ *       x &larr; RANDOM-SELECTION(population, FITNESS-FN)
+ *       y &larr; RANDOM-SELECTION(population, FITNESS-FN)
+ *       child &larr; REPRODUCE(x, y)
+ *       if (small random probability) then child &larr; MUTATE(child)
  *       add child to new_population
- *     population &lt;- new_population
+ *     population &larr; new_population
  *   until some individual is fit enough, or enough time has elapsed
  *   return the best individual in population, according to FITNESS-FN
  * --------------------------------------------------------------------------------
  * function REPRODUCE(x, y) returns an individual
  *   inputs: x, y, parent individuals
  *   
- *   n &lt;- LENGTH(x); c &lt;- random number from 1 to n
+ *   n &larr; LENGTH(x); c &larr; random number from 1 to n
  *   return APPEND(SUBSTRING(x, 1, c), SUBSTRING(y, c+1, n))
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/search/local/HillClimbingSearch.java
+++ b/aima-core/src/main/java/aima/core/search/local/HillClimbingSearch.java
@@ -18,11 +18,11 @@ import java.util.function.ToDoubleFunction;
  * <pre>
  * function HILL-CLIMBING(problem) returns a state that is a local maximum
  *
- *   current &lt;- MAKE-NODE(problem.INITIAL-STATE)
+ *   current &larr; MAKE-NODE(problem.INITIAL-STATE)
  *   loop do
- *     neighbor &lt;- a highest-valued successor of current
+ *     neighbor &larr; a highest-valued successor of current
  *     if neighbor.VALUE &lt;= current.VALUE then return current.STATE
- *     current &lt;- neighbor
+ *     current &larr; neighbor
  * </pre>
  * <p>
  * Figure 4.2 The hill-climbing search algorithm, which is the most basic local

--- a/aima-core/src/main/java/aima/core/search/local/SimulatedAnnealingSearch.java
+++ b/aima-core/src/main/java/aima/core/search/local/SimulatedAnnealingSearch.java
@@ -19,14 +19,14 @@ import java.util.function.ToDoubleFunction;
  * <pre>
  * function SIMULATED-ANNEALING(problem, schedule) returns a solution state
  *                    
- *   current &lt;- MAKE-NODE(problem.INITIAL-STATE)
+ *   current &larr; MAKE-NODE(problem.INITIAL-STATE)
  *   for t = 1 to INFINITY do
- *     T &lt;- schedule(t)
+ *     T &larr; schedule(t)
  *     if T = 0 then return current
- *     next &lt;- a randomly selected successor of current
- *     /\E &lt;- next.VALUE - current.value
- *     if /\E &gt; 0 then current &lt;- next
- *     else current &lt;- next only with probability e&circ;(/\E/T)
+ *     next &larr; a randomly selected successor of current
+ *     /\E &larr; next.VALUE - current.value
+ *     if /\E &gt; 0 then current &larr; next
+ *     else current &larr; next only with probability e&circ;(/\E/T)
  * </pre>
  * 
  * Figure 4.5 The simulated annealing search algorithm, a version of stochastic

--- a/aima-core/src/main/java/aima/core/search/nondeterministic/AndOrSearch.java
+++ b/aima-core/src/main/java/aima/core/search/nondeterministic/AndOrSearch.java
@@ -22,7 +22,7 @@ import java.util.Optional;
  *   if problem.GOAL-TEST(state) then return the empty plan
  *   if state is on path then return failure
  *   for each action in problem.ACTIONS(state) do
- *       plan <- AND-SEARCH(RESULTS(state, action), problem, [state | path])
+ *       plan &larr; AND-SEARCH(RESULTS(state, action), problem, [state | path])
  *       if plan != failure then return [action | plan]
  *   return failure
  * 
@@ -30,7 +30,7 @@ import java.util.Optional;
  * 
  * function AND-SEARCH(states, problem, path) returns a conditional plan, or failure
  *   for each s<sub>i</sub> in states do
- *      plan<sub>i</sub> <- OR-SEARCH(s<sub>i</sub>, problem, path)
+ *      plan<sub>i</sub> &larr; OR-SEARCH(s<sub>i</sub>, problem, path)
  *      if plan<sub>i</sub> = failure then return failure
  *   return [if s<sub>1</sub> then plan<sub>1</sub>
  *           else if s<sub>2</sub> then plan<sub>2</sub> ...
@@ -89,7 +89,7 @@ public class AndOrSearch<S, A> {
 	 *   if problem.GOAL-TEST(state) then return the empty plan
 	 *   if state is on path then return failure
 	 *   for each action in problem.ACTIONS(state) do
-	 *       plan <- AND-SEARCH(RESULTS(state, action), problem, [state | path])
+	 *       plan &larr; AND-SEARCH(RESULTS(state, action), problem, [state | path])
 	 *       if plan != failure then return [action | plan]
 	 *   return failure
 	 * </code>
@@ -128,7 +128,7 @@ public class AndOrSearch<S, A> {
 	 * <code>
 	 * function AND-SEARCH(states, problem, path) returns a conditional plan, or failure
 	 *   for each s<sub>i</sub> in states do
-	 *      plan<sub>i</sub> <- OR-SEARCH(s<sub>i</sub>, problem, path)
+	 *      plan<sub>i</sub> &larr; OR-SEARCH(s<sub>i</sub>, problem, path)
 	 *      if plan<sub>i</sub> = failure then return failure
 	 *   return [if s<sub>1</sub> then plan<sub>1</sub>
 	 *           else if s<sub>2</sub> then plan<sub>2</sub> ...

--- a/aima-core/src/main/java/aima/core/search/online/LRTAStarAgent.java
+++ b/aima-core/src/main/java/aima/core/search/online/LRTAStarAgent.java
@@ -24,13 +24,13 @@ import aima.core.util.datastructure.TwoKeyHashMap;
  *               s, a, the previous state and action, initially null
  *           
  *   if GOAL-TEST(s') then return stop
- *   if s' is a new state (not in H) then H[s'] &lt;- h(s')
+ *   if s' is a new state (not in H) then H[s'] &larr; h(s')
  *   if s is not null
- *     result[s, a] &lt;- s'
- *     H[s] &lt;-        min LRTA*-COST(s, b, result[s, b], H)
+ *     result[s, a] &larr; s'
+ *     H[s] &larr;        min LRTA*-COST(s, b, result[s, b], H)
  *             b (element of) ACTIONS(s)
- *   a &lt;- an action b in ACTIONS(s') that minimizes LRTA*-COST(s', b, result[s', b], H)
- *   s &lt;- s'
+ *   a &larr; an action b in ACTIONS(s') that minimizes LRTA*-COST(s', b, result[s', b], H)
+ *   s &larr; s'
  *   return a
  *   
  * function LRTA*-COST(s, a, s', H) returns a cost estimate
@@ -43,7 +43,7 @@ import aima.core.util.datastructure.TwoKeyHashMap;
  * space.<br>
  * <br>
  * <b>Note:</b> This algorithm fails to exit if the goal does not exist (e.g.
- * A<->B Goal=X), this could be an issue with the implementation. Comments
+ * A&harr;B Goal=X), this could be an issue with the implementation. Comments
  * welcome.
  * 
  * @author Ciaran O'Reilly

--- a/aima-core/src/main/java/aima/core/search/online/OnlineDFSAgent.java
+++ b/aima-core/src/main/java/aima/core/search/online/OnlineDFSAgent.java
@@ -28,15 +28,15 @@ import aima.core.util.datastructure.TwoKeyHashMap;
  *               s, a, the previous state and action, initially null
  *    
  *   if GOAL-TEST(s') then return stop
- *   if s' is a new state (not in untried) then untried[s'] &lt;- ACTIONS(s')
+ *   if s' is a new state (not in untried) then untried[s'] &larr; ACTIONS(s')
  *   if s is not null then
- *       result[s, a] &lt;- s'
+ *       result[s, a] &larr; s'
  *       add s to the front of the unbacktracked[s']
  *   if untried[s'] is empty then
  *       if unbacktracked[s'] is empty then return stop
- *       else a &lt;- an action b such that result[s', b] = POP(unbacktracked[s'])
- *   else a &lt;- POP(untried[s'])
- *   s &lt;- s'
+ *       else a &larr; an action b such that result[s', b] = POP(unbacktracked[s'])
+ *   else a &larr; POP(untried[s'])
+ *   s &larr; s'
  *   return a
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/search/uninformed/BreadthFirstSearch.java
+++ b/aima-core/src/main/java/aima/core/search/uninformed/BreadthFirstSearch.java
@@ -11,19 +11,19 @@ import aima.core.search.framework.qsearch.QueueSearch;
  * 
  * <pre>
  * function BREADTH-FIRST-SEARCH(problem) returns a solution, or failure
- *   node &lt;- a node with STATE = problem.INITIAL-STATE, PATH-COST=0
+ *   node &larr; a node with STATE = problem.INITIAL-STATE, PATH-COST=0
  *   if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
- *   frontier &lt;- a FIFO queue with node as the only element
- *   explored &lt;- an empty set
+ *   frontier &larr; a FIFO queue with node as the only element
+ *   explored &larr; an empty set
  *   loop do
  *      if EMPTY?(frontier) then return failure
- *      node &lt;- POP(frontier) // chooses the shallowest node in frontier
+ *      node &larr; POP(frontier) // chooses the shallowest node in frontier
  *      add node.STATE to explored
  *      for each action in problem.ACTIONS(node.STATE) do
- *          child &lt;- CHILD-NODE(problem, node, action)
+ *          child &larr; CHILD-NODE(problem, node, action)
  *          if child.STATE is not in explored or frontier then
  *              if problem.GOAL-TEST(child.STATE) then return SOLUTION(child)
- *              frontier &lt;- INSERT(child, frontier)
+ *              frontier &larr; INSERT(child, frontier)
  * </pre>
  * 
  * Figure 3.11 Breadth-first search on a graph.<br>

--- a/aima-core/src/main/java/aima/core/search/uninformed/DepthLimitedSearch.java
+++ b/aima-core/src/main/java/aima/core/search/uninformed/DepthLimitedSearch.java
@@ -21,11 +21,11 @@ import java.util.function.Consumer;
  *   if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
  *   else if limit = 0 then return cutoff
  *   else
- *       cutoff_occurred? &lt;- false
+ *       cutoff_occurred? &larr; false
  *       for each action in problem.ACTIONS(node.STATE) do
- *           child &lt;- CHILD-NODE(problem, node, action)
- *           result &lt;- RECURSIVE-DLS(child, problem, limit - 1)
- *           if result = cutoff then cutoff_occurred? &lt;- true
+ *           child &larr; CHILD-NODE(problem, node, action)
+ *           result &larr; RECURSIVE-DLS(child, problem, limit - 1)
+ *           if result = cutoff then cutoff_occurred? &larr; true
  *           else if result != failure then return result
  *       if cutoff_occurred? then return cutoff else return failure
  * </pre>

--- a/aima-core/src/main/java/aima/core/search/uninformed/IterativeDeepeningSearch.java
+++ b/aima-core/src/main/java/aima/core/search/uninformed/IterativeDeepeningSearch.java
@@ -16,7 +16,7 @@ import java.util.function.Consumer;
  * <pre>
  * function ITERATIVE-DEEPENING-SEARCH(problem) returns a solution, or failure
  *   for depth = 0 to infinity  do
- *     result &lt;- DEPTH-LIMITED-SEARCH(problem, depth)
+ *     result &larr; DEPTH-LIMITED-SEARCH(problem, depth)
  *     if result != cutoff then return result
  * </pre>
  * 

--- a/aima-core/src/main/java/aima/core/search/uninformed/UniformCostSearch.java
+++ b/aima-core/src/main/java/aima/core/search/uninformed/UniformCostSearch.java
@@ -15,18 +15,18 @@ import aima.core.search.framework.qsearch.QueueSearch;
  * 
  * <pre>
  * function UNIFORM-COST-SEARCH(problem) returns a solution, or failure
- *   node &lt;- a node with STATE = problem.INITIAL-STATE, PATH-COST = 0
- *   frontier &lt;- a priority queue ordered by PATH-COST, with node as the only element
- *   explored &lt;- an empty set
+ *   node &larr; a node with STATE = problem.INITIAL-STATE, PATH-COST = 0
+ *   frontier &larr; a priority queue ordered by PATH-COST, with node as the only element
+ *   explored &larr; an empty set
  *   loop do
  *      if EMPTY?(frontier) then return failure
- *      node &lt;- POP(frontier) // chooses the lowest-cost node in frontier
+ *      node &larr; POP(frontier) // chooses the lowest-cost node in frontier
  *      if problem.GOAL-TEST(node.STATE) then return SOLUTION(node)
  *      add node.STATE to explored
  *      for each action in problem.ACTIONS(node.STATE) do
- *          child &lt;- CHILD-NODE(problem, node, action)
+ *          child &larr; CHILD-NODE(problem, node, action)
  *          if child.STATE is not in explored or frontier then
- *             frontier &lt;- INSERT(child, frontier)
+ *             frontier &larr; INSERT(child, frontier)
  *          else if child.STATE is in frontier with higher PATH-COST then
  *             replace that frontier node with child
  * </pre>


### PR DESCRIPTION
Pseudocode in class javadoc often uses `<-` for assignment. This is not proper javadoc and confuses the NetBeans editor. Sometimes `&lt;-` is used, which is valid, and sometimes `&larr;` is used.

This pull request replaces all assignment operators with `&larr;`. It is guaranteed to be proper javadoc, and also this character is in [WGL4](https://en.wikipedia.org/wiki/Windows_Glyph_List_4), so it's generally available everywhere.

There are also several instances of `&harr;` replacement.

The instances of `<-` that are not in pseudocode javadoc are not changed.

The replacement was done with Search and Replace regexps in files and then manually verified afterwards.