### PR TITLE
Add Markov Decision Process to AIMA4e

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,12 @@ Java implementation of algorithms from Russell and Norvig's "Artificial Intellig
        <td><a href="https://github.com/aimacode/aima-pseudocode/blob/master/md/SATPlan.md">SATPlan</a></td>
        <td><a href="core/src/main/java/aima/core/logic/basic/propositional/inference/SATPlan.java">SATPlan</a></td>
    </tr>
+    <tr>
+       <td>17.?</td>
+       <td>??</td>
+       <td>Markov Decision Process</td>
+       <td><a href="core/src/main/java/aima/core/Probability/MarkovDecisionProcess.java">MarkovDecisionProcess</a></td>
+   </tr>
    <tr>
        <td></td>
        <td></td>

--- a/core/src/main/java/aima/core/Probability/MarkovDecisionProcess.java
+++ b/core/src/main/java/aima/core/Probability/MarkovDecisionProcess.java
@@ -52,7 +52,7 @@ public interface MarkovDecisionProcess<Stype, Atype> {
 	 *            the state.
 	 * @return the set of actions for state s.
 	 */
-	Set<Atype> ACTIONS(Stype s);
+	Set<Atype> Actions(Stype s);
 
 	/**
 	 * Return the probability of going from state s using action a to s' based

--- a/core/src/main/java/aima/core/Probability/MarkovDecisionProcess.java
+++ b/core/src/main/java/aima/core/Probability/MarkovDecisionProcess.java
@@ -1,0 +1,83 @@
+package aima.core.Probability;
+
+import java.util.Set;
+
+/**
+ * Artificial Intelligence A Modern Approach (4th Edition): Figure ?.?, page
+ * ???.<br>
+ * <br>
+ * 
+ * A sequential decision problem for a fully observable, stochastic environment
+ * with a Markovian transition model and additive rewards is called a <b>Markov
+ * decision process</b>, or <b>MDP</b>, and consists of a set of states (with an
+ * initial state s<sub>0</sub>; a set ACTIONS(s) of actions in each state; a
+ * transition model P(s' | s, a); and a reward function R(s).<br>
+ * <br>
+ * <b>Note:</b> Some definitions of MDPs allow the reward to depend on the
+ * action and outcome too, so the reward function is R(s, a, s'). This
+ * simplifies the description of some environments but does not change the
+ * problem in any fundamental way.
+ * 
+ * @param <Stype>
+ *            the state type.
+ * @param <Atype>
+ *            the action type.
+ * 
+ * @author Ritwik Sharma
+ * @author Ciaran O'Reilly
+ * @author Ravi Mohan
+ * 
+ */
+public interface MarkovDecisionProcess<Stype, Atype> {
+
+	/**
+	 * Get the set of states associated with the Markov decision process.
+	 * 
+	 * @return the set of states associated with the Markov decision process.
+	 */
+	Set<Stype> states();
+
+	/**
+	 * Get the initial state s<sub>0</sub> for this instance of a Markov
+	 * decision process.
+	 * 
+	 * @return the initial state s<sub>0</sub>.
+	 */
+	Stype getInitialState();
+
+	/**
+	 * Get the set of actions for state s.
+	 * 
+	 * @param s
+	 *            the state.
+	 * @return the set of actions for state s.
+	 */
+	Set<Atype> ACTIONS(Stype s);
+
+	/**
+	 * Return the probability of going from state s using action a to s' based
+	 * on the underlying transition model P(s' | s, a).
+	 * 
+	 * @param P
+	 *            transition model/probability
+	 * @param s'
+	 *            the state s' being transitioned to.
+	 * @param s
+	 *            the state s being transitions from.
+	 * @param a
+	 *            the action used to move from state s to s'.
+	 * @return the probability of going from state s using action a to s'.
+	 */
+	double P(Stype sDelta, Stype s, Atype a);
+
+	/**
+	 * Get the reward associated with being in state s.
+	 * 
+	 * @param R
+	 *            reward function 
+	 * @param s
+	 *            the state whose award is sought.
+	 * @return the reward associated with being in state s.
+	 */
+	double R(Stype s);
+}


### PR DESCRIPTION
Solves #188.
This PR consists:
1. Readme.md edit to add Markov Decision Process
2. Add MarkovDecisionProcess.java - reimplemented for AIMA4e and improved java doc to make it more closer according to the third edition AIMA book page 647 chapter 17.
      