### PR TITLE
Online-DFS-Agent - Clarify the need for the additional check if (!sPrime.equals(result.get(s, a))), which is not present in the pseudocode but required to stop it looping endlessly on certain test problems - and Added unit test for TableDrivenAgent in class TableDrivenAgentTest.java .

### DIFF
--- a/core/src/main/java/aima/core/agent/basic/OnlineDFSAgent.java
+++ b/core/src/main/java/aima/core/agent/basic/OnlineDFSAgent.java
@@ -75,7 +75,15 @@ public class OnlineDFSAgent<A, P, S> implements Agent<A, P> {
 		}
 		// if s' is a new state (not in untried) then untried[s'] <- ACTIONS(s')
 		untried.computeIfAbsent(sPrime, state -> actions(state));
+		
 		// if s is not null and s' != result[s, a] then do
+		// s: previous state
+		// s': current new state
+		// only if a previous state exists (s is not null and we can backtrack to s) and our current state is different from
+		// the previous state (s' != s), only then should we backtrack from our current state to a previous state 
+		// and assign the previous (now current) state and its actions as having already taken place whilst updating our then current
+		// (now previous) state to one that we can now backtrack to. If we don't add this check we will fall into an infinite loop.
+		
 		if (s != null && !sPrime.equals(result.get(s, a))) {
 			// result[s, a] <- s'
 			result.put(s, a, sPrime);

--- a/test/src/test/java/aima/test/unit/agent/TableDrivenAgentTest.java
+++ b/test/src/test/java/aima/test/unit/agent/TableDrivenAgentTest.java
@@ -1,17 +1,78 @@
 package aima.test.unit.agent;
 
+
+import java.util.ArrayList;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import aima.core.agent.api.Agent;
+import aima.core.agent.api.Rule;
+import aima.core.agent.basic.TableDrivenAgent;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 /**
  * @author Ciaran O'Reilly
+ * @author Haris Riaz
+ * @param <P>
+ * @param <A>
  */
-public class TableDrivenAgentTest {
-
+public class TableDrivenAgentTest<A, P>
+{
+	
+		// Actions defined as strings
+		private final String ACTION_1 = "action1";
+		private final String ACTION_2 = "action2";
+		private final String ACTION_3 = "action3";
+		public static final String NO_OP = "NO_OPERATION";
+		private Map<List<String>, String> perceptSequenceActions; // a parameterized table of actions, indexed by percept sequences defined as type
+																  // String, initially fully specified
+		private List<String> percept = new ArrayList<>(); // a parameterized sequence, initially empty of type String 
+    	private TableDrivenAgent <String, String> t1;     // TableDrivenAgent object parameterized as a string 
+		
+    	@Before
+		public void setUp()
+		{
+			perceptSequenceActions = new HashMap<List<String>,String>();
+			percept = new ArrayList<>();
+			percept.add("Percept1");
+			perceptSequenceActions.put(percept, ACTION_1);
+			percept.add("Percept2");
+			perceptSequenceActions.put(percept, ACTION_2);
+			percept.add("Percept3");
+			perceptSequenceActions.put(percept, ACTION_3);
+			
+	    	t1 = new TableDrivenAgent<String,String>(perceptSequenceActions); 
+	    	
+		}
+		
     @Ignore("TODO")
     @Test
-    public void testTODO() {
-        Assert.fail("TODO");
+    public void testExistingSequences() { 
+    	
+    	Assert.fail("TODO");
+    	Assert.assertEquals(ACTION_1,
+				t1.perceive((String) percept.get(0)));
+		Assert.assertEquals(ACTION_2,
+				t1.perceive((String) percept.get(1)));
+		Assert.assertEquals(ACTION_3,
+				t1.perceive((String) percept.get(2))); 
     }
+    
+    
+    /*@Test
+    public void testNonExistingSequence() {
+    	
+        Assert.assertEquals(ACTION_1,
+    			t1.perceive((String) percept.get(0)));
+        Assert.assertNotEquals(NO_OP,
+				t1.perceive((String) percept.get(2)));
+    }*/
+	
 }
+


### PR DESCRIPTION
This is a PR which:

- adds a unit test for the TableDrivenAgent.

- Clarifies the need for the additional check if (!sPrime.equals(result.get(s, a))), which is not present in the pseudocode of OnlineDFSAgent but is required to stop it looping endlessly on certain test problems

 I've set up the basic structure for the unit test with a generic implementation as best as I could understand, however, I do think this needs more work. I'm also having trouble with testing non-existing sequences, so any help on that would be appreciated. @utsavoza @norvig @samagra14 please review this PR and help me improve it. 

