### PR TITLE
Minor improvements in the map2d package (AIMA4e)

### DIFF
--- a/core/src/main/java/aima/core/environment/map2d/GoAction.java
+++ b/core/src/main/java/aima/core/environment/map2d/GoAction.java
@@ -13,7 +13,7 @@ public class GoAction {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj != null && obj instanceof GoAction) {
+		if (obj instanceof GoAction) {
 			return this.getGoTo().equals(((GoAction) obj).getGoTo());
 		}
 		return super.equals(obj);

--- a/core/src/main/java/aima/core/environment/map2d/InState.java
+++ b/core/src/main/java/aima/core/environment/map2d/InState.java
@@ -13,7 +13,7 @@ public class InState {
 
 	@Override
 	public boolean equals(Object obj) {
-		if (obj != null && obj instanceof InState) {
+		if (obj instanceof InState) {
 			return this.getLocation().equals(((InState) obj).getLocation());
 		}
 		return super.equals(obj);

--- a/core/src/main/java/aima/core/environment/map2d/Map2DFunctionFactory.java
+++ b/core/src/main/java/aima/core/environment/map2d/Map2DFunctionFactory.java
@@ -16,27 +16,24 @@ import aima.core.util.datastructure.Point2D;
  * Map2D environments.
  * 
  * @author Ciaran O'Reilly
+ * @author samagra
  *
  */
 public class Map2DFunctionFactory {
 	public static ActionsFunction<GoAction, InState> getActionsFunction(Map2D map) {
-		return (inState) -> {
-			return map.getLocationsLinkedTo(inState.getLocation()).stream().map(GoAction::new)
-					.collect(Collectors.toList());
-		};
+		return (inState) -> map.getLocationsLinkedTo(inState.getLocation()).stream().map(GoAction::new)
+				.collect(Collectors.toList());
 	}
 
 	public static StepCostFunction<GoAction, InState> getStepCostFunction(Map2D map) {
-		return (s, a, sPrime) -> {
-			return map.getDistance(s.getLocation(), sPrime.getLocation());
-		};
+		return (s, a, sPrime) -> map.getDistance(s.getLocation(), sPrime.getLocation());
 	}
 
-	public static ResultFunction<GoAction, InState> getResultFunction(Map2D map) {
+	public static ResultFunction<GoAction, InState> getResultFunction() {
 		return (state, action) -> new InState(action.getGoTo());
 	}
 
-	public static GoalTestPredicate<InState> getGoalTestPredicate(Map2D map, String... goalLocations) {
+	public static GoalTestPredicate<InState> getGoalTestPredicate(String... goalLocations) {
 		return inState -> {
 			for (String location : goalLocations) {
 				if (location.equals(inState.getLocation())) {

--- a/core/src/main/java/aima/core/environment/support/ProblemFactory.java
+++ b/core/src/main/java/aima/core/environment/support/ProblemFactory.java
@@ -46,8 +46,8 @@ public class ProblemFactory {
 
 		return new BasicProblem<>(new InState(initialState),
 				Map2DFunctionFactory.getActionsFunction(simplifidRoadMapOfPartOfRomania),
-				Map2DFunctionFactory.getResultFunction(simplifidRoadMapOfPartOfRomania),
-				Map2DFunctionFactory.getGoalTestPredicate(simplifidRoadMapOfPartOfRomania, goalLocations),
+				Map2DFunctionFactory.getResultFunction(),
+				Map2DFunctionFactory.getGoalTestPredicate(goalLocations),
 				Map2DFunctionFactory.getStepCostFunction(simplifidRoadMapOfPartOfRomania));
 	}
 
@@ -60,13 +60,13 @@ public class ProblemFactory {
 		}
 		return new Pair<>(new BasicProblem<>(new InState(initialState),
 				Map2DFunctionFactory.getActionsFunction(simplifidRoadMapOfPartOfRomania),
-				Map2DFunctionFactory.getResultFunction(simplifidRoadMapOfPartOfRomania),
-				Map2DFunctionFactory.getGoalTestPredicate(simplifidRoadMapOfPartOfRomania, goalLocation),
+				Map2DFunctionFactory.getResultFunction(),
+				Map2DFunctionFactory.getGoalTestPredicate(goalLocation),
 				Map2DFunctionFactory.getStepCostFunction(simplifidRoadMapOfPartOfRomania)),
 				new BasicProblem<>(new InState(goalLocation),
 						Map2DFunctionFactory.getActionsFunction(simplifidRoadMapOfPartOfRomania),
-						Map2DFunctionFactory.getResultFunction(simplifidRoadMapOfPartOfRomania),
-						Map2DFunctionFactory.getGoalTestPredicate(simplifidRoadMapOfPartOfRomania, goalLocation),
+						Map2DFunctionFactory.getResultFunction(),
+						Map2DFunctionFactory.getGoalTestPredicate(goalLocation),
 						Map2DFunctionFactory.getStepCostFunction(simplifidRoadMapOfPartOfRomania)));
 	}
 

--- a/test/src/test/java/aima/test/unit/search/adversarial/SearchForAdversarialActionFunctionTest.java
+++ b/test/src/test/java/aima/test/unit/search/adversarial/SearchForAdversarialActionFunctionTest.java
@@ -109,7 +109,7 @@ public class SearchForAdversarialActionFunctionTest {
 	public void testAIMA3eFig5_2() {
 		Game<InState, GoAction, String> game = new BasicGame<>(() -> new InState("A"), aima3eFig5_2PlayerFn,
 				Map2DFunctionFactory.getActionsFunction(aima3eFig5_2),
-				Map2DFunctionFactory.getResultFunction(aima3eFig5_2), aima3eFig5_2TerminalTestPredicate,
+				Map2DFunctionFactory.getResultFunction(), aima3eFig5_2TerminalTestPredicate,
 				aima3eFig5_2UtilityFn);
 
 		Assert.assertEquals(new GoAction("B"), searchForAdversarialAction(game, 100, 0, 200));


### PR DESCRIPTION
This PR makes minor modifications to the map2d package. This PR makes the following changes: 
* Converts Statement Lambdas to Expression lambdas wherever required.
* Removes the unnecessary null checks
* A Map2D object was unnecessarily passed into the `getResultFunction()` and the`getGoalTestPredicate()` function. This PR safely deletes the unnecessary Map2D method parameter.