### PR TITLE
FOL-FC-ASK implementation

### DIFF
--- a/core/src/main/java/aima/core/logic/api/firstorderlogic/Clause.java
+++ b/core/src/main/java/aima/core/logic/api/firstorderlogic/Clause.java
@@ -1,0 +1,8 @@
+package aima.core.logic.api.firstorderlogic;
+
+import aima.core.logic.basic.firstorder.kb.data.Literal;
+
+public interface Clause {
+    Clause standardizeVariables();
+    Literal getConsequence();
+}

--- a/core/src/main/java/aima/core/logic/api/firstorderlogic/Clause.java
+++ b/core/src/main/java/aima/core/logic/api/firstorderlogic/Clause.java
@@ -25,4 +25,13 @@ public interface Clause {
      * @return the consequence of the implication clause
      */
     Literal getConsequence();
+
+    boolean isDefiniteClause();
+
+    boolean isUnitClause();
+
+    boolean isImplicationDefiniteClause();
+
+    boolean isHornClause();
+
 }

--- a/core/src/main/java/aima/core/logic/api/firstorderlogic/Clause.java
+++ b/core/src/main/java/aima/core/logic/api/firstorderlogic/Clause.java
@@ -2,7 +2,27 @@ package aima.core.logic.api.firstorderlogic;
 
 import aima.core.logic.basic.firstorder.kb.data.Literal;
 
+/**
+ * An interface representing a First Order Logic (FOL) clause
+ *
+ * @author samagra .
+ */
 public interface Clause {
+
+    /**
+     * The <I>standardizeVariables()</I> replaces all variables in a given clause with
+     * new ones that have not been used before.
+     *
+     * @return a clause with its variables replaced by new ones that have not been
+     *      used before.
+     */
     Clause standardizeVariables();
+
+    /**
+     * <I>getConsequence()</I> returns the conclusion of a clause if the clause can be represented
+     * as an Implication.
+     *
+     * @return the consequence of the implication clause
+     */
     Literal getConsequence();
 }

--- a/core/src/main/java/aima/core/logic/api/firstorderlogic/Clause.java
+++ b/core/src/main/java/aima/core/logic/api/firstorderlogic/Clause.java
@@ -34,4 +34,5 @@ public interface Clause {
 
     boolean isHornClause();
 
+    int size();
 }

--- a/core/src/main/java/aima/core/logic/api/firstorderlogic/FOLKnowledgeBase.java
+++ b/core/src/main/java/aima/core/logic/api/firstorderlogic/FOLKnowledgeBase.java
@@ -1,0 +1,38 @@
+package aima.core.logic.api.firstorderlogic;
+
+import aima.core.logic.basic.firstorder.kb.data.Literal;
+import aima.core.logic.basic.firstorder.parsing.ast.Sentence;
+import aima.core.logic.basic.firstorder.parsing.ast.Term;
+import aima.core.logic.basic.firstorder.parsing.ast.Variable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface FOLKnowledgeBase {
+    /**
+     *
+     * @param sentence
+     */
+    void tell(String sentence);
+
+    /**
+     *
+     * @param sentences
+     */
+    void tell(Set<? extends Literal> sentences);
+
+    /**
+     *
+     * @return
+     */
+    List<Clause> getAllDefiniteClauseImplications();
+
+    boolean isRenaming(Literal sentence);
+    boolean isRenaming(Literal sentence,Set<Literal> base);
+
+    Set<Map<Variable,Term>> fetch(Clause q);
+
+
+
+}

--- a/core/src/main/java/aima/core/logic/api/firstorderlogic/FOLKnowledgeBase.java
+++ b/core/src/main/java/aima/core/logic/api/firstorderlogic/FOLKnowledgeBase.java
@@ -1,7 +1,6 @@
 package aima.core.logic.api.firstorderlogic;
 
 import aima.core.logic.basic.firstorder.kb.data.Literal;
-import aima.core.logic.basic.firstorder.parsing.ast.Sentence;
 import aima.core.logic.basic.firstorder.parsing.ast.Term;
 import aima.core.logic.basic.firstorder.parsing.ast.Variable;
 
@@ -9,30 +8,55 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * An interface representing the First Order Logic (FOL) Knowledge Base
+ *
+ * @author samagra
+ */
 public interface FOLKnowledgeBase {
     /**
+     * Adds the specified sentence to the knowledge base.
      *
-     * @param sentence
+     * @param sentence a fact to be added to the knowledge base.
      */
     void tell(String sentence);
 
     /**
+     * Adds the specified sentences to the knowledge base.
      *
-     * @param sentences
+     * @param sentences A set of facts to be added to the knowledge base.
      */
     void tell(Set<? extends Literal> sentences);
 
     /**
-     *
-     * @return
+     * @return A list of all the definite implication Clauses useful for inference
+     *      algorithms.
      */
     List<Clause> getAllDefiniteClauseImplications();
 
+
+    /**
+     * Used to check if a sentence is a <b>renaming</b> of a known fact. One sentence is a
+     * renaming of another if they are identical except for the names of the variables.
+     *
+     * @param sentence The sentence which is to be checked.
+     *
+     * @return a boolean which is true when the sentence is a <b>renaming</b> and else false.
+     */
     boolean isRenaming(Literal sentence);
-    boolean isRenaming(Literal sentence,Set<Literal> base);
 
-    Set<Map<Variable,Term>> fetch(Clause q);
+    boolean isRenaming(Literal sentence, Set<Literal> base);
 
+    /**
+     * <I>fetch(q)</I> returns all substitutions such that query q unifies with some sentence in
+     * the knowledge base.
+     *
+     * @param q The clause for which the substitutions are required
+     *
+     * @return A set of valid substitutions such that query q unifies with some
+     *      sentence in the knowledge base.
+     */
+    Set<Map<Variable, Term>> fetch(Clause q);
 
 
 }

--- a/core/src/main/java/aima/core/logic/basic/firstorder/BasicFOLKnowledgeBase.java
+++ b/core/src/main/java/aima/core/logic/basic/firstorder/BasicFOLKnowledgeBase.java
@@ -1,0 +1,64 @@
+package aima.core.logic.basic.firstorder;
+
+import aima.core.logic.api.firstorderlogic.Clause;
+import aima.core.logic.api.firstorderlogic.FOLKnowledgeBase;
+import aima.core.logic.basic.firstorder.domain.FOLDomain;
+import aima.core.logic.basic.firstorder.kb.data.Literal;
+import aima.core.logic.basic.firstorder.parsing.FOLLexer;
+import aima.core.logic.basic.firstorder.parsing.FOLParser;
+import aima.core.logic.basic.firstorder.parsing.ast.Sentence;
+import aima.core.logic.basic.firstorder.parsing.ast.Term;
+import aima.core.logic.basic.firstorder.parsing.ast.Variable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class BasicFOLKnowledgeBase implements FOLKnowledgeBase {
+
+    private List<Sentence> sentences = new ArrayList<>();
+    private FOLParser parser;
+    private List<Clause> allDefiniteClauseImplications = new ArrayList<>();
+
+    public BasicFOLKnowledgeBase(FOLDomain domain){
+        this.parser = new FOLParser(domain);
+    }
+
+    @Override
+    public void tell(String sentence) {
+        Sentence parsedSentence = parser.parse(sentence);
+        sentences.add(parsedSentence);
+        //TODO: A list of all the implication clauses
+    }
+
+    public int size(){
+        return sentences.size();
+    }
+
+    @Override
+    public void tell(Set<? extends Literal> sentences) {
+
+
+    }
+
+    @Override
+    public List<Clause> getAllDefiniteClauseImplications() {
+        return allDefiniteClauseImplications;
+    }
+
+    @Override
+    public boolean isRenaming(Literal sentence) {
+        return false;
+    }
+
+    @Override
+    public boolean isRenaming(Literal sentence, Set<Literal> base) {
+        return false;
+    }
+
+    @Override
+    public Set<Map<Variable, Term>> fetch(Clause q) {
+        return null;
+    }
+}

--- a/core/src/main/java/aima/core/logic/basic/firstorder/inference/FOLFCAsk.java
+++ b/core/src/main/java/aima/core/logic/basic/firstorder/inference/FOLFCAsk.java
@@ -9,47 +9,92 @@ import aima.core.logic.basic.firstorder.parsing.ast.Sentence;
 import aima.core.logic.basic.firstorder.parsing.ast.Term;
 import aima.core.logic.basic.firstorder.parsing.ast.Variable;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Artificial Intelligence A Modern Approach (4th Edition): Figure ?.?, page
+ * ??.<br>
+ * <br>
+ *
+ * <pre>
+ * function FOL-FC-ASK(KB, alpha) returns a substitution or false
+ *   inputs: KB, the knowledge base, a set of first order definite clauses
+ *           alpha, the query, an atomic sentence
+ *   local variables: new, the new sentences inferred on each iteration
+ *
+ *   repeat until new is empty
+ *      new &lt;- {}
+ *      for each rule in KB do
+ *          (p1 &circ; ... &circ; pn =&gt; q) &lt;- STANDARDIZE-VARIABLES(rule)
+ *          for each theta such that SUBST(theta, p1 &circ; ... &circ; pn) = SUBST(theta, p'1 &circ; ... &circ; p'n)
+ *                         for some p'1,...,p'n in KB
+ *              q' &lt;- SUBST(theta, q)
+ *              if q' does not unify with some sentence already in KB or new then
+ *                   add q' to new
+ *                   phi &lt;- UNIFY(q', alpha)
+ *                   if theta is not fail then return theta
+ *      add new to KB
+ *   return false
+ * </pre>
+ *
+ * Figure ?.? A conceptually straightforward, but very inefficient
+ * forward-chaining algorithm. On each iteration, it adds to KB all the atomic
+ * sentences that can be inferred in one step from the implication sentences and
+ * the atomic sentences already in KB.
+ *
+ * @author samagra
+ *
+ */
+
+
 public class FOLFCAsk {
+    //Variables to call SUBST(theta,q) and UNIFY(q',alpha)
     private SubstVisitor substVisitor;
     private Unifier unifier;
 
+    //Public constructor
     public FOLFCAsk() {
-        substVisitor= new SubstVisitor();
+        substVisitor = new SubstVisitor();
         unifier = new Unifier();
     }
-    public Map<Variable,Term> folFcAsk(FOLKnowledgeBase KB, Sentence query){
-        Set<Literal> newSentences = new HashSet<>();
-        do{
-            newSentences.clear();
 
-            for (Clause rule :
-                    KB.getAllDefiniteClauseImplications()) {
+    //function FOL-FC-ASK(KB, alpha) returns a substitution or false
+    //  inputs: KB, the knowledge base, a set of first order definite clauses
+    //           alpha, the query, an atomic sentence
+    public Map<Variable, Term> folFcAsk(FOLKnowledgeBase KB, Sentence query) {
+        //local variables: new, the new sentences inferred on each iteration
+        Set<Literal> newSentences = new HashSet<>();
+        //repeat until new is empty
+        do {
+            //new <- {}
+            newSentences.clear();
+            //for each rule in KB do
+            for (Clause rule : KB.getAllDefiniteClauseImplications()) {
+                //(p1^...^ pn =>q) <- STANDARDIZE-VARIABLES(rule)
                 Clause implication = rule.standardizeVariables();
-                // for each theta such that SUBST(theta, p1 ^ ... ^ pn) =
-                // SUBST(theta, p'1 ^ ... ^ p'n)
+                // for each theta such that SUBST(theta, p1 ^ ... ^ pn) = SUBST(theta, p'1 ^ ... ^ p'n)
                 // --- for some p'1,...,p'n in KB
                 for (Map<Variable, Term> theta :
                         KB.fetch(implication)) {
-                    Literal qPrime = substVisitor.subst(theta,implication.getConsequence());
-                    if(!KB.isRenaming(qPrime) && !KB.isRenaming(qPrime,newSentences)){
+                    //q' <- SUBST(theta,q)
+                    Literal qPrime = substVisitor.subst(theta, implication.getConsequence());
+                    //if q' does not unify with some sentence already in KB or new then
+                    if (!KB.isRenaming(qPrime) && !KB.isRenaming(qPrime, newSentences)) {
+                        //add q' to new
                         newSentences.add(qPrime);
-                        Map<Variable,Term> phi = unifier.unify(qPrime.getAtomicSentence(),query);
-                        if (phi != null){
-                            return phi;
-                        }
-
+                        //phi <- UNIFY(q', alpha)
+                        Map<Variable, Term> phi = unifier.unify(qPrime.getAtomicSentence(), query);
+                        // if phi is not fail then return phi
+                        if (phi != null) return phi;
                     }
-
                 }
-
             }
+            //add new to KB
             KB.tell(newSentences);
-        }while(!newSentences.isEmpty());
+        } while (!newSentences.isEmpty());
+        //return false
         return null; // here null represents a false substitution
     }
 }

--- a/core/src/main/java/aima/core/logic/basic/firstorder/inference/FOLFCAsk.java
+++ b/core/src/main/java/aima/core/logic/basic/firstorder/inference/FOLFCAsk.java
@@ -1,0 +1,55 @@
+package aima.core.logic.basic.firstorder.inference;
+
+import aima.core.logic.api.firstorderlogic.Clause;
+import aima.core.logic.api.firstorderlogic.FOLKnowledgeBase;
+import aima.core.logic.basic.firstorder.SubstVisitor;
+import aima.core.logic.basic.firstorder.Unifier;
+import aima.core.logic.basic.firstorder.kb.data.Literal;
+import aima.core.logic.basic.firstorder.parsing.ast.Sentence;
+import aima.core.logic.basic.firstorder.parsing.ast.Term;
+import aima.core.logic.basic.firstorder.parsing.ast.Variable;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class FOLFCAsk {
+    private SubstVisitor substVisitor;
+    private Unifier unifier;
+
+    public FOLFCAsk() {
+        substVisitor= new SubstVisitor();
+        unifier = new Unifier();
+    }
+    public Map<Variable,Term> folFcAsk(FOLKnowledgeBase KB, Sentence query){
+        Set<Literal> newSentences = new HashSet<>();
+        do{
+            newSentences.clear();
+
+            for (Clause rule :
+                    KB.getAllDefiniteClauseImplications()) {
+                Clause implication = rule.standardizeVariables();
+                // for each theta such that SUBST(theta, p1 ^ ... ^ pn) =
+                // SUBST(theta, p'1 ^ ... ^ p'n)
+                // --- for some p'1,...,p'n in KB
+                for (Map<Variable, Term> theta :
+                        KB.fetch(implication)) {
+                    Literal qPrime = substVisitor.subst(theta,implication.getConsequence());
+                    if(!KB.isRenaming(qPrime) && !KB.isRenaming(qPrime,newSentences)){
+                        newSentences.add(qPrime);
+                        Map<Variable,Term> phi = unifier.unify(qPrime.getAtomicSentence(),query);
+                        if (phi != null){
+                            return phi;
+                        }
+
+                    }
+
+                }
+
+            }
+            KB.tell(newSentences);
+        }while(!newSentences.isEmpty());
+        return null; // here null represents a false substitution
+    }
+}

--- a/core/src/main/java/aima/core/logic/basic/firstorder/kb/data/Clause.java
+++ b/core/src/main/java/aima/core/logic/basic/firstorder/kb/data/Clause.java
@@ -1,0 +1,62 @@
+package aima.core.logic.basic.firstorder.kb.data;
+
+import java.util.*;
+
+public class Clause implements aima.core.logic.api.firstorderlogic.Clause {
+
+    private Set<Literal> literals = new LinkedHashSet<>();
+    private Set<Literal> positiveLiterals = new LinkedHashSet<>();
+    private Set<Literal> negativeLiterals = new LinkedHashSet<>();
+
+    public Clause(){
+        this(new ArrayList<>());
+    }
+
+    public Clause(Literal... literals){
+        this(Arrays.asList(literals));
+    }
+
+    public Clause(List<Literal> literals) {
+        for (Literal literal :
+                literals) {
+            this.literals.add(literal);
+            if (literal.isPositiveLiteral()){
+                positiveLiterals.add(literal);
+            }
+            else {
+                negativeLiterals.add(literal);
+            }
+        }
+    }
+
+    @Override
+    public aima.core.logic.api.firstorderlogic.Clause standardizeVariables() {
+        return null;
+    }
+
+    @Override
+    public Literal getConsequence() {
+        return null;
+    }
+
+    @Override
+    public boolean isDefiniteClause() {
+        return (positiveLiterals.size() == 1);
+    }
+
+    @Override
+    public boolean isUnitClause() {
+        return (literals.size()==1);
+    }
+
+    @Override
+    public boolean isImplicationDefiniteClause() {
+        return (isDefiniteClause() && negativeLiterals.size()>=1);
+    }
+
+    @Override
+    public boolean isHornClause() {
+        return (positiveLiterals.size()<=1);
+    }
+
+}

--- a/core/src/main/java/aima/core/logic/basic/firstorder/kb/data/Clause.java
+++ b/core/src/main/java/aima/core/logic/basic/firstorder/kb/data/Clause.java
@@ -2,6 +2,12 @@ package aima.core.logic.basic.firstorder.kb.data;
 
 import java.util.*;
 
+/**
+ * @author Ciaran O' Reilly
+ * @author Anurag Rai
+ * @author samagra
+ */
+
 public class Clause implements aima.core.logic.api.firstorderlogic.Clause {
 
     private Set<Literal> literals = new LinkedHashSet<>();
@@ -36,6 +42,9 @@ public class Clause implements aima.core.logic.api.firstorderlogic.Clause {
 
     @Override
     public Literal getConsequence() {
+        if (isImplicationDefiniteClause()){
+            return positiveLiterals.iterator().next();
+        }
         return null;
     }
 
@@ -57,6 +66,11 @@ public class Clause implements aima.core.logic.api.firstorderlogic.Clause {
     @Override
     public boolean isHornClause() {
         return (positiveLiterals.size()<=1);
+    }
+
+    @Override
+    public int size() {
+        return literals.size();
     }
 
 }

--- a/core/src/main/java/aima/core/logic/basic/firstorder/kb/data/Literal.java
+++ b/core/src/main/java/aima/core/logic/basic/firstorder/kb/data/Literal.java
@@ -13,7 +13,7 @@ import aima.core.logic.basic.firstorder.parsing.ast.Term;
  * 
  */
 public class Literal {
-	private AtomicSentence atom = null;
+	private AtomicSentence atom;
 	private boolean negativeLiteral = false;
 	private String strRep = null;
 	private int hashCode = 0;

--- a/test/src/test/java/aima/test/unit/logic/firstorder/kb/BasicFOLKnowledgeBaseTest.java
+++ b/test/src/test/java/aima/test/unit/logic/firstorder/kb/BasicFOLKnowledgeBaseTest.java
@@ -1,0 +1,29 @@
+package aima.test.unit.logic.firstorder.kb;
+
+import aima.core.logic.basic.firstorder.BasicFOLKnowledgeBase;
+import aima.core.logic.basic.firstorder.domain.DomainFactory;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author samagra
+ */
+public class BasicFOLKnowledgeBaseTest {
+    private BasicFOLKnowledgeBase knowledgeBase;
+
+    @Before
+    public void setup(){
+        knowledgeBase = new BasicFOLKnowledgeBase(DomainFactory.kingsDomain());
+    }
+
+    @Test
+    public void tellTest(){
+        Assert.assertEquals(0,knowledgeBase.size());
+        knowledgeBase.tell("King(John)");
+        Assert.assertEquals(1,knowledgeBase.size());
+        knowledgeBase.tell("King(Richard)");
+        Assert.assertEquals(2,knowledgeBase.size());
+    }
+
+}

--- a/test/src/test/java/aima/test/unit/logic/firstorder/kb/data/ClauseTest.java
+++ b/test/src/test/java/aima/test/unit/logic/firstorder/kb/data/ClauseTest.java
@@ -1,0 +1,5 @@
+package aima.test.unit.logic.firstorder.kb.data;
+
+public class ClauseTest {
+    //TODO : A predefined list of atomic sentences
+}

--- a/test/src/test/java/aima/test/unit/logic/firstorder/kb/data/ClauseTest.java
+++ b/test/src/test/java/aima/test/unit/logic/firstorder/kb/data/ClauseTest.java
@@ -1,5 +1,71 @@
 package aima.test.unit.logic.firstorder.kb.data;
 
+import aima.core.logic.basic.firstorder.kb.data.Clause;
+import aima.core.logic.basic.firstorder.kb.data.Literal;
+import aima.core.logic.basic.firstorder.parsing.ast.Predicate;
+import aima.core.logic.basic.firstorder.parsing.ast.Term;
+import aima.core.logic.basic.firstorder.parsing.ast.Variable;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+/**
+ * @author samagra
+ */
+
 public class ClauseTest {
-    //TODO : A predefined list of atomic sentences
+    //A predefined list of atomic sentences
+    private Clause clause;
+    private Literal negatedLiteralOne;
+    private Literal negatedLiteralTwo;
+    private Literal positiveLiteral;
+
+    @Before
+    public void setup(){
+        Term[] terms = {new Variable("x")};
+        negatedLiteralOne = new Literal(new Predicate("King", Arrays.asList(terms)),true);
+        negatedLiteralTwo = new Literal(new Predicate("Greedy",Arrays.asList(terms)),true);
+        positiveLiteral = new Literal(new Predicate("Evil",Arrays.asList(terms)));
+    }
+
+    @Test
+    public void testConstructor(){
+        clause = new Clause();
+        Assert.assertEquals(0,clause.size());
+        clause = new Clause(negatedLiteralOne,negatedLiteralTwo);
+        Assert.assertEquals(2,clause.size());
+        Literal[] literals = {positiveLiteral,negatedLiteralTwo,negatedLiteralOne};
+        clause = new Clause(Arrays.asList(literals));
+        Assert.assertEquals(3,clause.size());
+    }
+
+    @Test
+    public void testDifferentTypesOfClauses(){
+        clause = new Clause(negatedLiteralOne);
+        Assert.assertTrue(clause.isHornClause());
+        Assert.assertTrue(clause.isUnitClause());
+        Assert.assertFalse(clause.isDefiniteClause());
+        Assert.assertFalse(clause.isImplicationDefiniteClause());
+        clause = new Clause(positiveLiteral);
+        Assert.assertTrue(clause.isHornClause());
+        Assert.assertTrue(clause.isUnitClause());
+        Assert.assertFalse(clause.isImplicationDefiniteClause());
+        Assert.assertTrue(clause.isDefiniteClause());
+        clause = new Clause(negatedLiteralOne,negatedLiteralTwo,positiveLiteral);
+        Assert.assertTrue(clause.isHornClause());
+        Assert.assertFalse(clause.isUnitClause());
+        Assert.assertTrue(clause.isDefiniteClause());
+        Assert.assertTrue(clause.isDefiniteClause());
+    }
+
+    @Test
+    public void testGetConsequence(){
+        clause = new Clause(negatedLiteralTwo,negatedLiteralOne);
+        Literal literal = clause.getConsequence();
+        Assert.assertNull(literal);
+        clause = new Clause(negatedLiteralOne,negatedLiteralTwo,positiveLiteral);
+        Assert.assertEquals(positiveLiteral,clause.getConsequence());
+    }
 }


### PR DESCRIPTION
This PR adds the implementation of the FOL-FC-ASK algorithm. This PR adds FOLFcAsk.java with the following dependencies.
* An interface to represent the FOL knowledge Base
* An interface to represent Clauses

I have added an interface to represent the FOL knowledge base so that alternate implementations of the KnowledgeBase can be added to the aima.extra module by simply implementing the interface. Also, this will make it easier to implement custom KnowledgeBases. Besides this, the implemented algorithm makes very little assumptions regarding the organisation of the KnowledgeBase.

However, I will be adding a concrete implementation of the KnowledgeBase for testing the algorithm. The KnowledgeBase interface, however, is not exhaustive. It will become richer as implementations of further algorithms are added.