### PR TITLE
fix(bug): SimmulatedAnnealingSearch with Math.random()

### DIFF
--- a/aima-core/src/main/java/aima/core/search/local/SimulatedAnnealingSearch.java
+++ b/aima-core/src/main/java/aima/core/search/local/SimulatedAnnealingSearch.java
@@ -206,7 +206,7 @@ public class SimulatedAnnealingSearch<S, A> implements SearchForActions<S, A>, S
 	// else current <- next only with probability e^(/\E/T)
 	private boolean shouldAccept(double temperature, double deltaE) {
 		return (deltaE > 0.0)
-				|| (new Random().nextDouble() <= probabilityOfAcceptance(temperature, deltaE));
+				|| (Math.random() <= probabilityOfAcceptance(temperature, deltaE));
 	}
 
 	private double getValue(Node<S, A> n) {


### PR DESCRIPTION
Replacing `new Random().nextDouble()` with `Math.random()` in `shouldAccept` method in order to guarantee an uniform distribution of random numbers between 0.0 and 1.0.

Solves issue #405. 